### PR TITLE
Adding support for a DataSource grid parameter

### DIFF
--- a/BlazorBootstrap.Demo.Hosted/Client/Models/Department.cs
+++ b/BlazorBootstrap.Demo.Hosted/Client/Models/Department.cs
@@ -1,0 +1,13 @@
+﻿namespace BlazorBootstrap.Demo.Hosted.Client;
+
+public class Department
+{
+    public string Name { get; set; }
+    public IEnumerable<Employee1> Employees { get; set; }
+
+    public Department(string name, IEnumerable<Employee1> employees)
+    {
+        Name = name;
+        Employees = employees;
+    }
+}

--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/Grid/GridDocumentation.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/Grid/GridDocumentation.razor
@@ -99,6 +99,10 @@
 <Callout Type="CalloutType.Default">Browser local storage is used to persist the Grid state. Common locations exist for persisting state are <b>Server-side storage</b>, <b>URL</b>, <b>Browser storage</b>, and <b>In-memory state container service</b>.</Callout>
 <Demo Type="typeof(Grid_Demo_16_Save_And_Load_Grid_Settings)" Tabs="true" />
 
+<SectionHeading Size="HeadingSize.H2" Text="Datasources" PageUrl="@pageUrl" HashTagName="datasources" />
+<div class="mb-3">Pass in a DataSource parameter value to be able to render grids dynamically.</div>
+<Demo Type="typeof(Grid_Demo_17_Datasources)" Tabs="true" />
+
 @code {
     private string pageUrl = "/grid";
     private string title = "Blazor Grid Component";

--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/Grid/Grid_Demo_17_Datasources.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/Grid/Grid_Demo_17_Datasources.razor
@@ -1,0 +1,50 @@
+﻿@foreach (var department in departments)
+{
+    <p>@department.Name Employees:</p>
+    <Grid TItem="Employee1" class="table table-hover table-bordered table-striped" DataProvider="EmployeesDataProvider" DataSource="department.Employees">
+        <GridColumn TItem="Employee1" HeaderText="Id" PropertyName="Id">
+            @context.Id
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Employee Name" PropertyName="Name">
+            @context.Name
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Designation" PropertyName="Designation">
+            @context.Designation
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="DOJ" PropertyName="DOJ">
+            @context.DOJ
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Active" PropertyName="IsActive">
+            @context.IsActive
+        </GridColumn>
+    </Grid>
+}
+
+@code {
+    private List<Department> departments = new List<Department>()
+    {
+        new Department("Research & Development", new List<Employee1> {
+            new Employee1 { Id = 107, Name = "Alice", Designation = "AI Engineer", DOJ = new DateOnly(1998, 11, 17), IsActive = true },
+            new Employee1 { Id = 103, Name = "Bob", Designation = "Senior DevOps Engineer", DOJ = new DateOnly(1985, 1, 5), IsActive = true },
+            new Employee1 { Id = 106, Name = "John", Designation = "Data Engineer", DOJ = new DateOnly(1995, 4, 17), IsActive = true },
+            new Employee1 { Id = 104, Name = "Pop", Designation = "Associate Architect", DOJ = new DateOnly(1985, 6, 8), IsActive = false },
+            new Employee1 { Id = 105, Name = "Ronald", Designation = "Senior Data Engineer", DOJ = new DateOnly(1991, 8, 23), IsActive = true }
+        }),
+        new Department("Development & Research", new List<Employee1> {
+            new Employee1 { Id = 102, Name = "Line", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 101, Name = "Daniel", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 108, Name = "Zayne", Designation = "Data Analyst", DOJ = new DateOnly(1991, 1, 1), IsActive = true },
+            new Employee1 { Id = 109, Name = "Isha", Designation = "App Maker", DOJ = new DateOnly(1996, 7, 1), IsActive = true }
+        })
+    };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private async Task<GridDataProviderResult<Employee1>> EmployeesDataProvider(GridDataProviderRequest<Employee1> request)
+    {
+        return await Task.FromResult(request.ApplyTo(request.DataSource));
+    }
+}

--- a/BlazorBootstrap.Demo.Server/Models/Department.cs
+++ b/BlazorBootstrap.Demo.Server/Models/Department.cs
@@ -1,0 +1,13 @@
+﻿namespace BlazorBootstrap.Demo.Server;
+
+public class Department
+{
+    public string Name { get; set; }
+    public IEnumerable<Employee1> Employees { get; set; }
+
+    public Department(string name, IEnumerable<Employee1> employees)
+    {
+        Name = name;
+        Employees = employees;
+    }
+}

--- a/BlazorBootstrap.Demo.Server/Pages/Grid/GridDocumentation.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/Grid/GridDocumentation.razor
@@ -99,6 +99,10 @@
 <Callout Type="CalloutType.Default">Browser local storage is used to persist the Grid state. Common locations exist for persisting state are <b>Server-side storage</b>, <b>URL</b>, <b>Browser storage</b>, and <b>In-memory state container service</b>.</Callout>
 <Demo Type="typeof(Grid_Demo_16_Save_And_Load_Grid_Settings)" Tabs="true" />
 
+<SectionHeading Size="HeadingSize.H2" Text="Datasources" PageUrl="@pageUrl" HashTagName="datasources" />
+<div class="mb-3">Pass in a DataSource parameter value to be able to render grids dynamically.</div>
+<Demo Type="typeof(Grid_Demo_17_Datasources)" Tabs="true" />
+
 @code {
     private string pageUrl = "/grid";
     private string title = "Blazor Grid Component";

--- a/BlazorBootstrap.Demo.Server/Pages/Grid/Grid_Demo_17_Datasources.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/Grid/Grid_Demo_17_Datasources.razor
@@ -1,0 +1,50 @@
+﻿@foreach (var department in departments)
+{
+    <p>@department.Name Employees:</p>
+    <Grid TItem="Employee1" class="table table-hover table-bordered table-striped" DataProvider="EmployeesDataProvider" DataSource="department.Employees">
+        <GridColumn TItem="Employee1" HeaderText="Id" PropertyName="Id">
+            @context.Id
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Employee Name" PropertyName="Name">
+            @context.Name
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Designation" PropertyName="Designation">
+            @context.Designation
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="DOJ" PropertyName="DOJ">
+            @context.DOJ
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Active" PropertyName="IsActive">
+            @context.IsActive
+        </GridColumn>
+    </Grid>
+}
+
+@code {
+    private List<Department> departments = new List<Department>()
+    {
+        new Department("Research & Development", new List<Employee1> {
+            new Employee1 { Id = 107, Name = "Alice", Designation = "AI Engineer", DOJ = new DateOnly(1998, 11, 17), IsActive = true },
+            new Employee1 { Id = 103, Name = "Bob", Designation = "Senior DevOps Engineer", DOJ = new DateOnly(1985, 1, 5), IsActive = true },
+            new Employee1 { Id = 106, Name = "John", Designation = "Data Engineer", DOJ = new DateOnly(1995, 4, 17), IsActive = true },
+            new Employee1 { Id = 104, Name = "Pop", Designation = "Associate Architect", DOJ = new DateOnly(1985, 6, 8), IsActive = false },
+            new Employee1 { Id = 105, Name = "Ronald", Designation = "Senior Data Engineer", DOJ = new DateOnly(1991, 8, 23), IsActive = true }
+        }),
+        new Department("Development & Research", new List<Employee1> {
+            new Employee1 { Id = 102, Name = "Line", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 101, Name = "Daniel", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 108, Name = "Zayne", Designation = "Data Analyst", DOJ = new DateOnly(1991, 1, 1), IsActive = true },
+            new Employee1 { Id = 109, Name = "Isha", Designation = "App Maker", DOJ = new DateOnly(1996, 7, 1), IsActive = true }
+        })
+    };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private async Task<GridDataProviderResult<Employee1>> EmployeesDataProvider(GridDataProviderRequest<Employee1> request)
+    {
+        return await Task.FromResult(request.ApplyTo(request.DataSource));
+    }
+}

--- a/BlazorBootstrap.Demo/Models/Department.cs
+++ b/BlazorBootstrap.Demo/Models/Department.cs
@@ -1,0 +1,14 @@
+﻿namespace BlazorBootstrap.Demo.Models
+{
+    public class Department
+    {
+        public string Name { get; set; }
+        public IEnumerable<Employee1> Employees { get; set; }
+
+        public Department(string name, IEnumerable<Employee1> employees)
+        {
+            Name = name;
+            Employees = employees;
+        }
+    }
+}

--- a/BlazorBootstrap.Demo/Pages/Grid/GridDocumentation.razor
+++ b/BlazorBootstrap.Demo/Pages/Grid/GridDocumentation.razor
@@ -99,6 +99,10 @@
 <Callout Type="CalloutType.Default">Browser local storage is used to persist the Grid state. Common locations exist for persisting state are <b>Server-side storage</b>, <b>URL</b>, <b>Browser storage</b>, and <b>In-memory state container service</b>.</Callout>
 <Demo Type="typeof(Grid_Demo_16_Save_And_Load_Grid_Settings)" Tabs="true" />
 
+<SectionHeading Size="HeadingSize.H2" Text="Datasources" PageUrl="@pageUrl" HashTagName="datasources" />
+<div class="mb-3">Pass in a DataSource parameter value to be able to render grids dynamically.</div>
+<Demo Type="typeof(Grid_Demo_17_Datasources)" Tabs="true" />
+
 @code {
     private string pageUrl = "/grid";
     private string title = "Blazor Grid Component";

--- a/BlazorBootstrap.Demo/Pages/Grid/Grid_Demo_17_Datasources.razor
+++ b/BlazorBootstrap.Demo/Pages/Grid/Grid_Demo_17_Datasources.razor
@@ -1,0 +1,52 @@
+﻿@using BlazorBootstrap.Demo.Models;
+
+@foreach (var department in departments)
+{
+    <p>@department.Name Employees:</p>
+    <Grid TItem="Employee1" class="table table-hover table-bordered table-striped" DataProvider="EmployeesDataProvider" DataSource="department.Employees">
+        <GridColumn TItem="Employee1" HeaderText="Id" PropertyName="Id">
+            @context.Id
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Employee Name" PropertyName="Name">
+            @context.Name
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Designation" PropertyName="Designation">
+            @context.Designation
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="DOJ" PropertyName="DOJ">
+            @context.DOJ
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Active" PropertyName="IsActive">
+            @context.IsActive
+        </GridColumn>
+    </Grid>
+}
+
+@code {
+    private List<Department> departments = new List<Department>()
+    {
+        new Department("Research & Development", new List<Employee1> {
+            new Employee1 { Id = 107, Name = "Alice", Designation = "AI Engineer", DOJ = new DateOnly(1998, 11, 17), IsActive = true },
+            new Employee1 { Id = 103, Name = "Bob", Designation = "Senior DevOps Engineer", DOJ = new DateOnly(1985, 1, 5), IsActive = true },
+            new Employee1 { Id = 106, Name = "John", Designation = "Data Engineer", DOJ = new DateOnly(1995, 4, 17), IsActive = true },
+            new Employee1 { Id = 104, Name = "Pop", Designation = "Associate Architect", DOJ = new DateOnly(1985, 6, 8), IsActive = false },
+            new Employee1 { Id = 105, Name = "Ronald", Designation = "Senior Data Engineer", DOJ = new DateOnly(1991, 8, 23), IsActive = true }
+        }),
+        new Department("Development & Research", new List<Employee1> {
+            new Employee1 { Id = 102, Name = "Line", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 101, Name = "Daniel", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 108, Name = "Zayne", Designation = "Data Analyst", DOJ = new DateOnly(1991, 1, 1), IsActive = true },
+            new Employee1 { Id = 109, Name = "Isha", Designation = "App Maker", DOJ = new DateOnly(1996, 7, 1), IsActive = true }
+        })
+    };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private async Task<GridDataProviderResult<Employee1>> EmployeesDataProvider(GridDataProviderRequest<Employee1> request)
+    {
+        return await Task.FromResult(request.ApplyTo(request.DataSource));
+    }
+}

--- a/blazorbootstrap/Components/Grid/Grid.razor.cs
+++ b/blazorbootstrap/Components/Grid/Grid.razor.cs
@@ -212,7 +212,8 @@ public partial class Grid<TItem> : BaseComponent
             PageNumber = this.AllowPaging ? GridCurrentState.PageIndex : 0,
             PageSize = this.AllowPaging ? this.pageSize : 0,
             Sorting = this.AllowSorting ? (GridCurrentState.Sorting ?? GetDefaultSorting()) : null,
-            Filters = this.AllowFiltering ? GetFilters() : null
+            Filters = this.AllowFiltering ? GetFilters() : null,
+            DataSource = this.DataSource
         };
 
         if (DataProvider != null)
@@ -228,7 +229,7 @@ public partial class Grid<TItem> : BaseComponent
                 items = new List<TItem> { };
                 totalCount = 0;
             }
-        }
+        }         
 
         requestInProgress = false;
 
@@ -292,6 +293,11 @@ public partial class Grid<TItem> : BaseComponent
     /// The provider should always return an instance of 'GridDataProviderResult', and 'null' is not allowed.
     /// </summary>
     [Parameter, EditorRequired] public GridDataProviderDelegate<TItem> DataProvider { get; set; }
+
+    /// <summary>
+    /// DataSource allows you to optionally, directly pass in the data that gets used by the DataProvider.
+    /// </summary>
+    [Parameter] public IEnumerable<TItem>? DataSource { get; set; }
 
     /// <summary>
     /// Gets or sets the pagination alignment.

--- a/blazorbootstrap/Models/GridDataProviderRequest.cs
+++ b/blazorbootstrap/Models/GridDataProviderRequest.cs
@@ -22,6 +22,12 @@ public class GridDataProviderRequest<TItem>
     /// </summary>
     public IEnumerable<FilterItem> Filters { get; init; }
 
+    /// <summary>
+    /// Optional source for the data that the DataProvider can consume.
+    /// Useful for when you have more than one grid in use at once and need to use different data sources for each.
+    /// </summary>
+    public IEnumerable<TItem>? DataSource { get; init; }
+
     public GridDataProviderResult<TItem> ApplyTo(IEnumerable<TItem> data)
     {
         if (data == null)

--- a/docs/docs/components/grid.md
+++ b/docs/docs/components/grid.md
@@ -23,6 +23,7 @@ Use Blazor Bootstrap grid component to display tabular data from the data source
 | ChildContent | RenderFragment | | ✔️ | Specifies the content to be rendered inside the grid. |
 | EmptyText | string | No records to display | | Shows text on no records. |
 | DataProvider | `GridDataProviderDelegate<TItem>` | | ✔️ | DataProvider is for items to render. The provider should always return an instance of `GridDataProviderResult`, and `null` is not allowed. |
+| DataSource | `IEnumerable<TItem>` | | | Allows you to optionally pass in data for the DataProvider to consume via `GridDataProviderRequest.DataSource`. This is useful when you are rendering grids dynamically, i.e. in loops |
 | GridSettingsChanged | `EventCallback<GridSettings>` | | | This event is fired when the grid state is changed |
 | PageSize | int | Gets or sets the page size of the grid. | | 10 |
 | PaginationAlignment | enum | `Alignment.Start` | | Gets or sets the pagination alignment. Use `Alignment.Start` or `Alignment.Center` or `Alignment.End`. |
@@ -1095,7 +1096,8 @@ Browser local storage is used to persist the Grid state. Common locations exist 
 </Grid>
 ```
 
-```cs {5,6,16-26,28-38} showLineNumbers
+```cshtml {1,6,7} showLineNumbers
+
 @code {
     BlazorBootstrap.Grid<Employee1> grid;
     private IEnumerable<Employee1> employees;
@@ -1136,6 +1138,7 @@ Browser local storage is used to persist the Grid state. Common locations exist 
         return settings;
     }
 
+
     private IEnumerable<Employee1> GetEmployees()
     {
         return new List<Employee1>
@@ -1158,3 +1161,64 @@ Browser local storage is used to persist the Grid state. Common locations exist 
 ```
 
 [See demo here](https://demos.blazorbootstrap.com/grid#save-and-load-grid-settings)
+
+### DataSource
+
+Need to create grids in a loop where the data source for the grid changes every iteration? This example shows how you can pass in the data your grid needs at the point of rendering the grid.
+
+```cshtml {1,6,7} showLineNumbers
+@foreach (var department in departments)
+{
+    <p>@department.Name Employees:</p>
+    <Grid TItem="Employee1" class="table table-hover table-bordered table-striped" DataProvider="EmployeesDataProvider" DataSource="department.Employees">
+        <GridColumn TItem="Employee1" HeaderText="Id" PropertyName="Id">
+            @context.Id
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Employee Name" PropertyName="Name">
+            @context.Name
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Designation" PropertyName="Designation">
+            @context.Designation
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="DOJ" PropertyName="DOJ">
+            @context.DOJ
+        </GridColumn>
+        <GridColumn TItem="Employee1" HeaderText="Active" PropertyName="IsActive">
+            @context.IsActive
+        </GridColumn>
+    </Grid>
+}
+```
+
+```cs {5,6,16-26,28-38} showLineNumbers
+@code {
+    private List<Department> departments = new List<Department>()
+    {
+        new Department("Research & Development", new List<Employee1> {
+            new Employee1 { Id = 107, Name = "Alice", Designation = "AI Engineer", DOJ = new DateOnly(1998, 11, 17), IsActive = true },
+            new Employee1 { Id = 103, Name = "Bob", Designation = "Senior DevOps Engineer", DOJ = new DateOnly(1985, 1, 5), IsActive = true },
+            new Employee1 { Id = 106, Name = "John", Designation = "Data Engineer", DOJ = new DateOnly(1995, 4, 17), IsActive = true },
+            new Employee1 { Id = 104, Name = "Pop", Designation = "Associate Architect", DOJ = new DateOnly(1985, 6, 8), IsActive = false },
+            new Employee1 { Id = 105, Name = "Ronald", Designation = "Senior Data Engineer", DOJ = new DateOnly(1991, 8, 23), IsActive = true }
+        }),
+        new Department("Development & Research", new List<Employee1> {
+            new Employee1 { Id = 102, Name = "Line", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 101, Name = "Daniel", Designation = "Architect", DOJ = new DateOnly(1977, 1, 12), IsActive = true },
+            new Employee1 { Id = 108, Name = "Zayne", Designation = "Data Analyst", DOJ = new DateOnly(1991, 1, 1), IsActive = true },
+            new Employee1 { Id = 109, Name = "Isha", Designation = "App Maker", DOJ = new DateOnly(1996, 7, 1), IsActive = true }
+        })
+    };
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private async Task<GridDataProviderResult<Employee1>> EmployeesDataProvider(GridDataProviderRequest<Employee1> request)
+    {
+        return await Task.FromResult(request.ApplyTo(request.DataSource));
+    }
+}
+```
+
+[See demo here](https://demos.blazorbootstrap.com/grid#datasources)


### PR DESCRIPTION
This enables a data-source for the grid to be passed in when defining the grid, i.e. `<Grid DataSource="Employees"`

I have a need to render grids in a loop where the source of data for the grid changed every iteration. DataProvider on it's own doesn't work for this scenario, so now you can pass in the data source as part of each loop iteration and have the DataProvider consume this.

Tested. Documentation and demos updated.