### PR TITLE
docs/intro to docs/getting-started

### DIFF
--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/Charts/ChartsDocumentation.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/Charts/ChartsDocumentation.razor
@@ -26,7 +26,7 @@
 </Callout>
 
 <SectionHeading Size="HeadingSize.H4" Text="Charts Setup" PageUrl="@pageUrl" HashTagName="charts-setup" />
-Refer <a href="http://getblazorbootstrap.com/docs/intro#starter-template">starter template</a> for charts setup.
+Refer <a href="http://getblazorbootstrap.com/docs/getting-started/blazor-webassembly#starter-template">starter template</a> for charts setup.
 
 <SectionHeading Size="HeadingSize.H4" Text="Bar Chart" PageUrl="@pageUrl" HashTagName="bar-chart" />
 <Demo Type="typeof(Charts_Demo_01_BarChart_Examples)" Tabs="true" />

--- a/BlazorBootstrap.Demo.Server/Pages/Charts/ChartsDocumentation.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/Charts/ChartsDocumentation.razor
@@ -26,7 +26,7 @@
 </Callout>
 
 <SectionHeading Size="HeadingSize.H4" Text="Charts Setup" PageUrl="@pageUrl" HashTagName="charts-setup" />
-Refer <a href="http://getblazorbootstrap.com/docs/intro#starter-template">starter template</a> for charts setup.
+Refer <a href="http://getblazorbootstrap.com/docs/getting-started/blazor-webassembly#starter-template">starter template</a> for charts setup.
 
 <SectionHeading Size="HeadingSize.H4" Text="Bar Chart" PageUrl="@pageUrl" HashTagName="bar-chart" />
 <Demo Type="typeof(Charts_Demo_01_BarChart_Examples)" Tabs="true" />

--- a/BlazorBootstrap.Demo/Pages/Charts/ChartsDocumentation.razor
+++ b/BlazorBootstrap.Demo/Pages/Charts/ChartsDocumentation.razor
@@ -26,7 +26,7 @@
 </Callout>
 
 <SectionHeading Size="HeadingSize.H4" Text="Charts Setup" PageUrl="@pageUrl" HashTagName="charts-setup" />
-Refer <a href="http://getblazorbootstrap.com/docs/intro#starter-template">starter template</a> for charts setup.
+Refer <a href="http://getblazorbootstrap.com/docs/getting-started/blazor-webassembly#starter-template">starter template</a> for charts setup.
 
 <SectionHeading Size="HeadingSize.H4" Text="Bar Chart" PageUrl="@pageUrl" HashTagName="bar-chart" />
 <Demo Type="typeof(Charts_Demo_01_BarChart_Examples)" Tabs="true" />

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   Enterprise-class Blazor Bootstrap Component library built on the Blazor and Bootstrap CSS framework.
   <br>
-  <a href="https://getblazorbootstrap.com/docs/intro"><strong>Explore Blazor Bootstrap docs »</strong></a>
+  <a href="https://getblazorbootstrap.com/docs/getting-started/blazor-webassembly"><strong>Explore Blazor Bootstrap docs »</strong></a>
   <br>
 </p>
 
@@ -41,7 +41,7 @@ Get started any way you want
 
   ![image](https://user-images.githubusercontent.com/2337067/233800604-43986ae7-27dd-4f17-9af6-c2f1a6f07097.png)
 
-- Read the [Getting started page](https://getblazorbootstrap.com/docs/intro) for information on the framework installation, contents, examples, and more.
+- Read the [Getting started page](https://getblazorbootstrap.com/docs/getting-started/blazor-webassembly) for information on the framework installation, contents, examples, and more.
 
 ## Blazor Bootstrap Components
 

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -21,7 +21,7 @@ Get started any way you want
 
   ![image](https://user-images.githubusercontent.com/2337067/233800604-43986ae7-27dd-4f17-9af6-c2f1a6f07097.png)
 
-- Read the [Getting started page](https://getblazorbootstrap.com/docs/intro) for information on the framework installation, contents, examples, and more.
+- Read the [Getting started page](https://getblazorbootstrap.com/docs/getting-started/blazor-webassembly) for information on the framework installation, contents, examples, and more.
 
 ## Online Demos
 


### PR DESCRIPTION
Corrected 404 links from docs/intro. Replaced with what seems to be the desired path, to /docs/getting-started/blazor-webassembly