### PR TITLE
Change namespace for IServiceCollection extensions

### DIFF
--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/server/Snippet_03_Starter_Template_Register_services_Program.cs
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/server/Snippet_03_Starter_Template_Register_services_Program.cs
@@ -1,5 +1,1 @@
-﻿using BlazorBootstrap; // Add this line
-
-...
-         
-builder.Services.AddBlazorBootstrap(); // Add this line
+﻿builder.Services.AddBlazorBootstrap(); // Add this line

--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/server/Snippet_04_Starter_Template_Imports.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/server/Snippet_04_Starter_Template_Imports.razor
@@ -1,1 +1,1 @@
-﻿@using BlazorBootstrap;
+﻿@using BlazorBootstrap

--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/webassembly/Snippet_03_Starter_Template_Register_services_Program.cs
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/webassembly/Snippet_03_Starter_Template_Register_services_Program.cs
@@ -1,5 +1,1 @@
-﻿using BlazorBootstrap; // Add this line
-
-...
-         
-builder.Services.AddBlazorBootstrap(); // Add this line
+﻿builder.Services.AddBlazorBootstrap(); // Add this line

--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/webassembly/Snippet_04_Starter_Template_Imports.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/GettingStarted/webassembly/Snippet_04_Starter_Template_Imports.razor
@@ -1,1 +1,1 @@
-﻿@using BlazorBootstrap;
+﻿@using BlazorBootstrap

--- a/BlazorBootstrap.Demo.Hosted/Client/Program.cs
+++ b/BlazorBootstrap.Demo.Hosted/Client/Program.cs
@@ -1,4 +1,3 @@
-using BlazorBootstrap;
 using BlazorBootstrap.Demo.Hosted.Client;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 

--- a/BlazorBootstrap.Demo.Hosted/Server/Program.cs
+++ b/BlazorBootstrap.Demo.Hosted/Server/Program.cs
@@ -1,4 +1,3 @@
-using BlazorBootstrap;
 using BlazorBootstrap.Demo.Hosted.Client;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/BlazorBootstrap.Demo.Server/Pages/GettingStarted/server/Snippet_03_Starter_Template_Register_services_Program.cs
+++ b/BlazorBootstrap.Demo.Server/Pages/GettingStarted/server/Snippet_03_Starter_Template_Register_services_Program.cs
@@ -1,5 +1,1 @@
-﻿using BlazorBootstrap; // Add this line
-
-...
-         
-builder.Services.AddBlazorBootstrap(); // Add this line
+﻿builder.Services.AddBlazorBootstrap(); // Add this line

--- a/BlazorBootstrap.Demo.Server/Pages/GettingStarted/server/Snippet_04_Starter_Template_Imports.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/GettingStarted/server/Snippet_04_Starter_Template_Imports.razor
@@ -1,1 +1,1 @@
-﻿@using BlazorBootstrap;
+﻿@using BlazorBootstrap

--- a/BlazorBootstrap.Demo.Server/Pages/GettingStarted/webassembly/Snippet_03_Starter_Template_Register_services_Program.cs
+++ b/BlazorBootstrap.Demo.Server/Pages/GettingStarted/webassembly/Snippet_03_Starter_Template_Register_services_Program.cs
@@ -1,5 +1,1 @@
-﻿using BlazorBootstrap; // Add this line
-
-...
-         
-builder.Services.AddBlazorBootstrap(); // Add this line
+﻿builder.Services.AddBlazorBootstrap(); // Add this line

--- a/BlazorBootstrap.Demo.Server/Pages/GettingStarted/webassembly/Snippet_04_Starter_Template_Imports.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/GettingStarted/webassembly/Snippet_04_Starter_Template_Imports.razor
@@ -1,1 +1,1 @@
-﻿@using BlazorBootstrap;
+﻿@using BlazorBootstrap

--- a/BlazorBootstrap.Demo.Server/Program.cs
+++ b/BlazorBootstrap.Demo.Server/Program.cs
@@ -1,4 +1,3 @@
-using BlazorBootstrap;
 using BlazorBootstrap.Demo.Server;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/BlazorBootstrap.Demo/Pages/GettingStarted/server/Snippet_03_Starter_Template_Register_services_Program.cs
+++ b/BlazorBootstrap.Demo/Pages/GettingStarted/server/Snippet_03_Starter_Template_Register_services_Program.cs
@@ -1,5 +1,1 @@
-﻿using BlazorBootstrap; // Add this line
-
-...
-         
-builder.Services.AddBlazorBootstrap(); // Add this line
+﻿builder.Services.AddBlazorBootstrap(); // Add this line

--- a/BlazorBootstrap.Demo/Pages/GettingStarted/server/Snippet_04_Starter_Template_Imports.razor
+++ b/BlazorBootstrap.Demo/Pages/GettingStarted/server/Snippet_04_Starter_Template_Imports.razor
@@ -1,1 +1,1 @@
-﻿@using BlazorBootstrap;
+﻿@using BlazorBootstrap

--- a/BlazorBootstrap.Demo/Pages/GettingStarted/webassembly/Snippet_03_Starter_Template_Register_services_Program.cs
+++ b/BlazorBootstrap.Demo/Pages/GettingStarted/webassembly/Snippet_03_Starter_Template_Register_services_Program.cs
@@ -1,5 +1,1 @@
-﻿using BlazorBootstrap; // Add this line
-
-...
-         
-builder.Services.AddBlazorBootstrap(); // Add this line
+﻿builder.Services.AddBlazorBootstrap(); // Add this line

--- a/BlazorBootstrap.Demo/Pages/GettingStarted/webassembly/Snippet_04_Starter_Template_Imports.razor
+++ b/BlazorBootstrap.Demo/Pages/GettingStarted/webassembly/Snippet_04_Starter_Template_Imports.razor
@@ -1,1 +1,1 @@
-﻿@using BlazorBootstrap;
+﻿@using BlazorBootstrap

--- a/BlazorBootstrap.Demo/Program.cs
+++ b/BlazorBootstrap.Demo/Program.cs
@@ -1,4 +1,3 @@
-using BlazorBootstrap;
 using BlazorBootstrap.Demo;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;

--- a/blazorbootstrap/Config.cs
+++ b/blazorbootstrap/Config.cs
@@ -1,4 +1,6 @@
-﻿namespace BlazorBootstrap;
+﻿using BlazorBootstrap;
+
+namespace Microsoft.Extensions.DependencyInjection;
 
 public static class Config
 {


### PR DESCRIPTION
This changes the namespace of the `IServiceCollection` extension methods to `Microsoft.Extensions.DependencyInjection`. This eliminates the need of importing `using BlazorBootstrap` within `Program.cs`

In addition this PR removes the not necessary `;` for the `_Imports.razor` setup guide.