### PR TITLE
Added null check for chart tooltipLine beforeDraw event. Fixes #283.

### DIFF
--- a/blazorbootstrap/wwwroot/blazor.bootstrap.js
+++ b/blazorbootstrap/wwwroot/blazor.bootstrap.js
@@ -701,7 +701,7 @@ window.blazorChart.line = {
             const tooltipLine = {
                 id: 'tooltipLine',
                 beforeDraw: chart => {
-                    if (chart.tooltip._active && chart.tooltip._active.length) {
+                    if (chart.tooltip?._active && chart.tooltip?._active.length) {
                         const ctx = chart.ctx;
                         ctx.save();
                         const activePoint = chart.tooltip._active[0];


### PR DESCRIPTION
Added a null check to this event. From testing with two charts, it seems like this fixed the issues I was having in #283. 