### PR TITLE
Add more levels of navigation to sidebar

### DIFF
--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/Sidebar/SidebarDocumentation.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/Sidebar/SidebarDocumentation.razor
@@ -12,10 +12,9 @@
 <SectionHeading Size="HeadingSize.H2" Text="Basic usage" PageUrl="@pageUrl" HashTagName="basic-usage" />
 <Demo Type="typeof(Sidebar_Demo_01_Basic_Usage)" Tabs="true" />
 
-<SectionHeading Size="HeadingSize.H2" Text="Two level navigation" PageUrl="@pageUrl" HashTagName="two-level-navigation" />
+<SectionHeading Size="HeadingSize.H2" Text="Multi level navigation" PageUrl="@pageUrl" HashTagName="multi-level-navigation" />
 <div class="mb-3">Use NavItem's <code>Id</code> and <code>ParentId</code> to set the parent-child relation.</div>
-<Demo Type="typeof(Sidebar_Demo_02_Two_level_navigation)" Tabs="true" />
-<Callout Type="CalloutType.Default" Heading="NOTE">At this moment, two levels of navigation are supported.</Callout>
+<Demo Type="typeof(Sidebar_Demo_02_Multi_level_navigation)" Tabs="true" />
 
 <SectionHeading Size="HeadingSize.H2" Text="Change icons color" PageUrl="@pageUrl" HashTagName="change-icons-color" />
 <div class="mb-3">Set <code>IconColor</code> property to change the color.</div>

--- a/BlazorBootstrap.Demo.Hosted/Client/Pages/Sidebar/Sidebar_Demo_02_Multi_level_navigation.razor
+++ b/BlazorBootstrap.Demo.Hosted/Client/Pages/Sidebar/Sidebar_Demo_02_Multi_level_navigation.razor
@@ -34,6 +34,15 @@
             new NavItem { Id = "10", Href = "/currency-input", IconName = IconName.CurrencyDollar, Text = "Currency Input", ParentId="8"},
             new NavItem { Id = "11", Href = "/number-input", IconName = IconName.InputCursor, Text = "Number Input", ParentId="8"},
             new NavItem { Id = "12", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="8"},
+
+            new NavItem { Id = "13", IconName = IconName.ToggleOn, Text = "Level 1"},
+            new NavItem { Id = "14", IconName = IconName.ToggleOff, Text = "Level 2", ParentId="13"},
+            new NavItem { Id = "15", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="14"},
+
+            new NavItem { Id = "16", IconName = IconName.Airplane, Text = "Level 1"},
+            new NavItem { Id = "17", IconName = IconName.Alarm, Text = "Level 2", ParentId="16"},
+            new NavItem { Id = "18", IconName = IconName.App, Text = "Level 3", ParentId="17"},
+            new NavItem { Id = "19", Href = "/switch", IconName = IconName.ToggleOn, Text = "Level 4", ParentId="18"}
         };
 
         return navItems;

--- a/BlazorBootstrap.Demo.Server/Pages/Sidebar/SidebarDocumentation.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/Sidebar/SidebarDocumentation.razor
@@ -12,10 +12,9 @@
 <SectionHeading Size="HeadingSize.H2" Text="Basic usage" PageUrl="@pageUrl" HashTagName="basic-usage" />
 <Demo Type="typeof(Sidebar_Demo_01_Basic_Usage)" Tabs="true" />
 
-<SectionHeading Size="HeadingSize.H2" Text="Two level navigation" PageUrl="@pageUrl" HashTagName="two-level-navigation" />
+<SectionHeading Size="HeadingSize.H2" Text="Multi level navigation" PageUrl="@pageUrl" HashTagName="multi-level-navigation" />
 <div class="mb-3">Use NavItem's <code>Id</code> and <code>ParentId</code> to set the parent-child relation.</div>
-<Demo Type="typeof(Sidebar_Demo_02_Two_level_navigation)" Tabs="true" />
-<Callout Type="CalloutType.Default" Heading="NOTE">At this moment, two levels of navigation are supported.</Callout>
+<Demo Type="typeof(Sidebar_Demo_02_Multi_level_navigation)" Tabs="true" />
 
 <SectionHeading Size="HeadingSize.H2" Text="Change icons color" PageUrl="@pageUrl" HashTagName="change-icons-color" />
 <div class="mb-3">Set <code>IconColor</code> property to change the color.</div>
@@ -44,6 +43,8 @@
 <SectionHeading Size="HeadingSize.H2" Text="Customize sidebar" PageUrl="@pageUrl" HashTagName="customize-sidebar" />
 <div class="mb-3">Developers can customize the sidebar color by changing the CSS variables, as mentioned in the below example.</div>
 <Demo Type="typeof(Sidebar_Demo_09_Customize_Sidebar)" Tabs="true" />
+
+
 
 @code {
     private string pageUrl = "/sidebar";

--- a/BlazorBootstrap.Demo.Server/Pages/Sidebar/Sidebar_Demo_02_Multi_level_navigation.razor
+++ b/BlazorBootstrap.Demo.Server/Pages/Sidebar/Sidebar_Demo_02_Multi_level_navigation.razor
@@ -34,6 +34,15 @@
             new NavItem { Id = "10", Href = "/currency-input", IconName = IconName.CurrencyDollar, Text = "Currency Input", ParentId="8"},
             new NavItem { Id = "11", Href = "/number-input", IconName = IconName.InputCursor, Text = "Number Input", ParentId="8"},
             new NavItem { Id = "12", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="8"},
+
+            new NavItem { Id = "13", IconName = IconName.ToggleOn, Text = "Level 1"},
+            new NavItem { Id = "14", IconName = IconName.ToggleOff, Text = "Level 2", ParentId="13"},
+            new NavItem { Id = "15", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="14"},
+
+            new NavItem { Id = "16", IconName = IconName.Airplane, Text = "Level 1"},
+            new NavItem { Id = "17", IconName = IconName.Alarm, Text = "Level 2", ParentId="16"},
+            new NavItem { Id = "18", IconName = IconName.App, Text = "Level 3", ParentId="17"},
+            new NavItem { Id = "19", Href = "/switch", IconName = IconName.ToggleOn, Text = "Level 4", ParentId="18"}
         };
 
         return navItems;

--- a/BlazorBootstrap.Demo/Pages/Sidebar/SidebarDocumentation.razor
+++ b/BlazorBootstrap.Demo/Pages/Sidebar/SidebarDocumentation.razor
@@ -12,10 +12,9 @@
 <SectionHeading Size="HeadingSize.H2" Text="Basic usage" PageUrl="@pageUrl" HashTagName="basic-usage" />
 <Demo Type="typeof(Sidebar_Demo_01_Basic_Usage)" Tabs="true" />
 
-<SectionHeading Size="HeadingSize.H2" Text="Two level navigation" PageUrl="@pageUrl" HashTagName="two-level-navigation" />
+<SectionHeading Size="HeadingSize.H2" Text="Multi level navigation" PageUrl="@pageUrl" HashTagName="multi-level-navigation" />
 <div class="mb-3">Use NavItem's <code>Id</code> and <code>ParentId</code> to set the parent-child relation.</div>
-<Demo Type="typeof(Sidebar_Demo_02_Two_level_navigation)" Tabs="true" />
-<Callout Type="CalloutType.Default" Heading="NOTE">At this moment, two levels of navigation are supported.</Callout>
+<Demo Type="typeof(Sidebar_Demo_02_Multi_level_navigation)" Tabs="true" />
 
 <SectionHeading Size="HeadingSize.H2" Text="Change icons color" PageUrl="@pageUrl" HashTagName="change-icons-color" />
 <div class="mb-3">Set <code>IconColor</code> property to change the color.</div>

--- a/BlazorBootstrap.Demo/Pages/Sidebar/Sidebar_Demo_02_Multi_level_navigation.razor
+++ b/BlazorBootstrap.Demo/Pages/Sidebar/Sidebar_Demo_02_Multi_level_navigation.razor
@@ -34,6 +34,15 @@
             new NavItem { Id = "10", Href = "/currency-input", IconName = IconName.CurrencyDollar, Text = "Currency Input", ParentId="8"},
             new NavItem { Id = "11", Href = "/number-input", IconName = IconName.InputCursor, Text = "Number Input", ParentId="8"},
             new NavItem { Id = "12", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="8"},
+
+            new NavItem { Id = "13", IconName = IconName.ToggleOn, Text = "Level 1"},
+            new NavItem { Id = "14", IconName = IconName.ToggleOff, Text = "Level 2", ParentId="13"},
+            new NavItem { Id = "15", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="14"},
+
+            new NavItem { Id = "16", IconName = IconName.Airplane, Text = "Level 1"},
+            new NavItem { Id = "17", IconName = IconName.Alarm, Text = "Level 2", ParentId="16"},
+            new NavItem { Id = "18", IconName = IconName.App, Text = "Level 3", ParentId="17"},
+            new NavItem { Id = "19", Href = "/switch", IconName = IconName.ToggleOn, Text = "Level 4", ParentId="18"}
         };
 
         return navItems;

--- a/blazorbootstrap/Components/Sidebar/SidebarItem.razor
+++ b/blazorbootstrap/Components/Sidebar/SidebarItem.razor
@@ -65,7 +65,9 @@
                          Href="@childItem.Href"
                          Text="@childItem.Text"
                          Target="@childItem.Target"
-                         Match="@childItem.Match"/>
+                         Match="@childItem.Match"
+                         HasChilds="@childItem.HasChilds"
+                         ChildItems="@childItem.ChildItems"/>
         }
     }
 </div>


### PR DESCRIPTION
This PR adds support for multi-level drop downs in infite amounts. 

The docs needs to be updated for this. I've tested it down to level 5. Most common use-case would be 3 levels I guess.

We achieve this by running recurive building of sub-menus.

Not sure if it breaks anything which I have not on my radar but demo app works fine for me. Feel free to test the PR with all your needs.

