### PR TITLE
Allow to specify class on NavItems

### DIFF
--- a/BlazorBootstrap.Demo.RCL/Pages/Sidebar/SidebarDocumentation.razor
+++ b/BlazorBootstrap.Demo.RCL/Pages/Sidebar/SidebarDocumentation.razor
@@ -45,6 +45,10 @@
 <div class="mb-3">Developers can customize the sidebar color by changing the CSS variables, as mentioned in the below example.</div>
 <Demo Type="typeof(Sidebar_Demo_09_Customize_Sidebar)" Tabs="true" />
 
+<SectionHeading Size="HeadingSize.H2" Text="Apply custom CSS class to NavItem" PageUrl="@pageUrl" HashTagName="apply-custom-css-class-to-navitem" />
+<div class="mb-3">Set the <b>Class</b> property of a <b>NavItem</b> to apply a custom CSS class.</div>
+<Demo Type="typeof(Sidebar_Demo_10_Apply_Custom_CSS_Class_to_NavItem)" Tabs="true" />
+
 @code {
     private string pageUrl = "/sidebar";
     private string title = "Blazor Sidebar Component";

--- a/BlazorBootstrap.Demo.RCL/Pages/Sidebar/Sidebar_Demo_02_Two_level_navigation.razor
+++ b/BlazorBootstrap.Demo.RCL/Pages/Sidebar/Sidebar_Demo_02_Two_level_navigation.razor
@@ -30,10 +30,10 @@
             new NavItem { Id = "7", Href = "/sidebar", IconName = IconName.LayoutSidebarInset, Text = "Sidebar", ParentId="4"},
 
             new NavItem { Id = "8", IconName = IconName.WindowPlus, Text = "Forms" },
-            new NavItem { Id = "9", Href = "/autocomplete", IconName = IconName.InputCursorText, Text = "Auto Complete", ParentId="8"},
-            new NavItem { Id = "10", Href = "/currency-input", IconName = IconName.CurrencyDollar, Text = "Currency Input", ParentId="8"},
-            new NavItem { Id = "11", Href = "/number-input", IconName = IconName.InputCursor, Text = "Number Input", ParentId="8"},
-            new NavItem { Id = "12", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="8"},
+            new NavItem { Id = "9", Href = "/autocomplete", IconName = IconName.InputCursorText, Text = "Auto Complete", ParentId="8", Class="px-3"},
+            new NavItem { Id = "10", Href = "/currency-input", IconName = IconName.CurrencyDollar, Text = "Currency Input", ParentId="8", Class="px-3"},
+            new NavItem { Id = "11", Href = "/number-input", IconName = IconName.InputCursor, Text = "Number Input", ParentId="8", Class="px-3"},
+            new NavItem { Id = "12", Href = "/switch", IconName = IconName.ToggleOn, Text = "Switch", ParentId="8", Class="px-3"},
         };
 
         return navItems;

--- a/BlazorBootstrap.Demo.RCL/Pages/Sidebar/Sidebar_Demo_10_Apply_Custom_CSS_Class_to_NavItem.razor
+++ b/BlazorBootstrap.Demo.RCL/Pages/Sidebar/Sidebar_Demo_10_Apply_Custom_CSS_Class_to_NavItem.razor
@@ -25,9 +25,9 @@
             new NavItem { Id = "3", Href = "/icons", IconName = IconName.PersonSquare, Text = "Icons", ParentId="2"},
 
             new NavItem { Id = "4", IconName = IconName.ExclamationTriangleFill, Text = "Components" },
-            new NavItem { Id = "5", Href = "/alerts", IconName = IconName.CheckCircleFill, Text = "Alerts", ParentId="4"},
-            new NavItem { Id = "6", Href = "/breadcrumb", IconName = IconName.SegmentedNav, Text = "Breadcrumb", ParentId="4"},
-            new NavItem { Id = "7", Href = "/sidebar", IconName = IconName.LayoutSidebarInset, Text = "Sidebar", ParentId="4"},
+            new NavItem { Id = "5", Href = "/alerts", IconName = IconName.CheckCircleFill, Text = "Alerts", ParentId="4", Class="px-3"},
+            new NavItem { Id = "6", Href = "/breadcrumb", IconName = IconName.SegmentedNav, Text = "Breadcrumb", ParentId="4", Class="px-3"},
+            new NavItem { Id = "7", Href = "/sidebar", IconName = IconName.LayoutSidebarInset, Text = "Sidebar", ParentId="4", Class="px-3"},
 
             new NavItem { Id = "8", IconName = IconName.WindowPlus, Text = "Forms" },
             new NavItem { Id = "9", Href = "/autocomplete", IconName = IconName.InputCursorText, Text = "Auto Complete", ParentId="8"},

--- a/blazorbootstrap/Components/Sidebar/SidebarItem.razor
+++ b/blazorbootstrap/Components/Sidebar/SidebarItem.razor
@@ -65,7 +65,8 @@
                          Href="@childItem.Href"
                          Text="@childItem.Text"
                          Target="@childItem.Target"
-                         Match="@childItem.Match"/>
+                         Match="@childItem.Match"
+                         Class="@childItem.Class" />
         }
     }
 </div>

--- a/blazorbootstrap/Components/Sidebar/SidebarItemGroup.razor
+++ b/blazorbootstrap/Components/Sidebar/SidebarItemGroup.razor
@@ -13,7 +13,7 @@
                          Text="@item.Text"
                          Target="@item.Target"
                          Match="@item.Match"
-                         HasChilds="@item.HasChilds"
+                         HasChilds="@item.HasChildItems"
                          ChildItems="@item.ChildItems"
                          Class="@item.Class"/>
         }

--- a/blazorbootstrap/Components/Sidebar/SidebarItemGroup.razor
+++ b/blazorbootstrap/Components/Sidebar/SidebarItemGroup.razor
@@ -14,7 +14,8 @@
                          Target="@item.Target"
                          Match="@item.Match"
                          HasChilds="@item.HasChilds"
-                         ChildItems="@item.ChildItems"/>
+                         ChildItems="@item.ChildItems"
+                         Class="@item.Class"/>
         }
     }
 </nav>

--- a/blazorbootstrap/Models/NavItem.cs
+++ b/blazorbootstrap/Models/NavItem.cs
@@ -4,17 +4,28 @@ public class NavItem
 {
     #region Properties, Indexers
 
+    /// <summary>
+    /// Gets or sets the collection of child navigation items.
+    /// </summary>
     internal IEnumerable<NavItem>? ChildItems { get; set; }
 
     /// <summary>
-    /// Gets or sets the custom icon name.
+    /// Gets or sets an additional CSS class.
+    /// </summary>
+    public string? Class { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the custom icon to display.
     /// </summary>
     public string? CustomIconName { get; set; }
 
-    internal bool HasChilds { get; set; }
+    /// <summary>
+    /// Gets or sets a Boolean value indicating whether the navigation item has child items.
+    /// </summary>
+    internal bool HasChildItems { get; set; }
 
     /// <summary>
-    /// Gets or sets the href.
+    /// Gets or sets the HyperText Reference (href).
     /// </summary>
     public string? Href { get; set; }
 
@@ -57,11 +68,6 @@ public class NavItem
     /// Gets or sets the navigation link text.
     /// </summary>
     public string? Text { get; set; }
-    
-    /// <summary>
-    /// Gets or sets an additional css class for the item
-    /// </summary>
-    public string? Class { get; set; }
 
     #endregion
 }

--- a/blazorbootstrap/Models/NavItem.cs
+++ b/blazorbootstrap/Models/NavItem.cs
@@ -57,6 +57,11 @@ public class NavItem
     /// Gets or sets the navigation link text.
     /// </summary>
     public string? Text { get; set; }
+    
+    /// <summary>
+    /// Gets or sets an additional css class for the item
+    /// </summary>
+    public string? Class { get; set; }
 
     #endregion
 }

--- a/blazorbootstrap/Models/SidebarDataProviderRequest.cs
+++ b/blazorbootstrap/Models/SidebarDataProviderRequest.cs
@@ -26,7 +26,7 @@ public class SidebarDataProviderRequest
 
             if (childNavItems is not null && childNavItems.Any())
             {
-                navItem.HasChilds = true;
+                navItem.HasChildItems = true;
                 navItem.ChildItems = childNavItems;
             }
         }


### PR DESCRIPTION
This PR allows the user to specify a custom class for each `NavItem`. The purpose of this is to override the default CSS behaviour with more functionality.

This addresses #276

You can give the NavItems now a padding class for example which results in this:
![grafik](https://github.com/vikramlearning/blazorbootstrap/assets/32510006/0a170784-e2bc-4692-8b9d-a34da0485410)
