### PR TITLE
Fix #390

### DIFF
--- a/blazorbootstrap/Components/Tooltip/Tooltip.razor.cs
+++ b/blazorbootstrap/Components/Tooltip/Tooltip.razor.cs
@@ -19,7 +19,13 @@ public partial class Tooltip : BlazorBootstrapComponentBase
     {
         if (disposing)
         {
-            await JS.InvokeVoidAsync("window.blazorBootstrap.tooltip.dispose", ElementRef);
+            try {
+                await JS.InvokeVoidAsync("window.blazorBootstrap.tooltip.dispose", ElementRef);
+            }
+            catch (JSDisconnectedException)
+            {
+                // ignored
+            }
             objRef?.Dispose();
         }
 


### PR DESCRIPTION
Simply try/catch to suppress console errors on tooltip disposal