### PR TITLE
Fix the typo in documentation

### DIFF
--- a/docs/docs/03-content/icons.md
+++ b/docs/docs/03-content/icons.md
@@ -23,7 +23,7 @@ Blazor Bootstrap icon component will display an icon from any icon font.
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | Color | `IconColor` | Gets or sets the icon color. | | `IconColor.None` | 1.9.0 |
 | CustomIconName | string | Specify custom icons of your own, like `fontawesome`. Example: `fas fa-alarm-clock` | ✔️ | | 1.0.0 |

--- a/docs/docs/04-forms/autocomplete.md
+++ b/docs/docs/04-forms/autocomplete.md
@@ -12,7 +12,7 @@ sidebar_position: 1
 Blazor Bootstrap autocomplete component is a textbox that offers the users suggestions as they type from the data source. And it supports client-side and server-side filtering.
 
 ## Parameters
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | DataProvider | delegate | null | ✔️ | DataProvider is for items to render. The provider should always return an instance of `AutoCompleteDataProviderResult`, and null is not allowed. | 0.4.0 |
 | Disabled | bool | false | | Is AutoComplete disabled. | 0.4.0 |

--- a/docs/docs/05-components/accordion.md
+++ b/docs/docs/05-components/accordion.md
@@ -15,7 +15,7 @@ Build vertically collapsing accordions in combination with our Collapse componen
 
 ## Accordion Parameters
 
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | null | ✔️ | Specifies the content to be rendered inside this <see cref="Collapse"/>.| 1.7.0 |
 | Flush | bool | false | | Removes borders and rounded corners to render accordions edge-to-edge with their parent container. | 1.7.0 |
@@ -41,7 +41,7 @@ Build vertically collapsing accordions in combination with our Collapse componen
 
 ## AccordionItem Parameters
 
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | Content | RenderFragment | null | ✔️ | Specifies the content to be rendered inside the `AccordionItem`. | 1.7.0 |
 | IsActive | bool | false | | Gets or sets the active `AccordionItem`. | 1.7.0 |

--- a/docs/docs/05-components/alerts.md
+++ b/docs/docs/05-components/alerts.md
@@ -13,7 +13,7 @@ Provide contextual feedback messages for typical user actions with the handful o
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |--|--|--|--|--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside the alert. | | |
 | Color | `AlertColor` | Gets or sets the alert color. | | `AlertColor.None` |

--- a/docs/docs/05-components/breadcrumb.md
+++ b/docs/docs/05-components/breadcrumb.md
@@ -13,7 +13,7 @@ Blazor Bootstrap breadcrumb component indicates the current page's location with
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |--|--|--|--|--|
 | Items | `List<BreadcrumbItem>` | List of all the items. | ✔️ | |
 

--- a/docs/docs/05-components/buttons.md
+++ b/docs/docs/05-components/buttons.md
@@ -13,7 +13,7 @@ Use Blazor Bootstrap button styles for actions in forms, dialogs, and more with 
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | Active | bool | When set to `true`, places the component in the active state with active styling. | | false | 1.0.0 |
 | Block | bool | Makes the button to span the full width of a parent. | | false | 1.0.0 |

--- a/docs/docs/05-components/callout.md
+++ b/docs/docs/05-components/callout.md
@@ -13,7 +13,7 @@ Blazor Bootstrap callout component provides content presentation in a visually d
 
 ## Parameters
 
-| Name | Type | Default | Required | Descritpion |
+| Name | Type | Default | Required | Description |
 |:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | | ✔️ | Specifies the content to be rendered inside this. |
 | Heading | string | | | Gets or sets the callout heading. |

--- a/docs/docs/05-components/card.md
+++ b/docs/docs/05-components/card.md
@@ -21,7 +21,7 @@ A card is a flexible and extensible content container. It includes options for h
 
 ### Card Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 | Color | `CardColor` | Gets or sets the card color. | | `CardColor.None` | 1.10.0 |
@@ -29,31 +29,31 @@ A card is a flexible and extensible content container. It includes options for h
 
 ### CardBody Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 
 ### CardFooter Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 
 ### CardGroup Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 
 ### CardHeader Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 
 ### CardLink Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 | Disabled | bool | When set to 'true', disables the component's functionality and places it in a disabled state. | | | 1.10.0 |
@@ -63,20 +63,20 @@ A card is a flexible and extensible content container. It includes options for h
 
 ### CardSubTitle Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 | Size | `HeadingSize` | Gets or sets the heading size. | | `HeadingSize.H6` | 1.10.0 |
 
 ### CardText Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 
 ### CardTitle Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | ✔️ | | 1.10.0 |
 | Size | `HeadingSize` | Gets or sets the heading size. | | `HeadingSize.H5` | 1.10.0 |

--- a/docs/docs/05-components/dropdown.md
+++ b/docs/docs/05-components/dropdown.md
@@ -16,7 +16,7 @@ They are toggled by clicking, not by hovering; this is an intentional design dec
 
 ## Dropdown Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | AutoClose | bool | Enables or disables the auto close. | | true | 1.10.0 |
 | AutoCloseBehavior | `DropdownAutoCloseBehavior` | Gets or sets the auto close behavior of the dropdown. | | `DropdownAutoCloseBehavior.Both` | 1.10.0 |
@@ -28,7 +28,7 @@ They are toggled by clicking, not by hovering; this is an intentional design dec
 
 ## DropdownToggleButton Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside the DropdownToggleButton. | | | 1.10.0 |
 | Color | `ButtonColor` | Gets or sets the button color. | | | 1.10.0 |
@@ -36,7 +36,7 @@ They are toggled by clicking, not by hovering; this is an intentional design dec
 
 ## DropdownActionButton Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside the DropdownActionButton. | | | 1.10.0 |
 | Color | `ButtonColor` | Gets or sets the button color. | | | 1.10.0 |
@@ -44,20 +44,20 @@ They are toggled by clicking, not by hovering; this is an intentional design dec
 
 ## DropdownMenu Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside the DropdownMenu. | | | 1.10.0 |
 | Position | `DropdownMenuPosition` | Gets or sets the dropdown menu position. | | | 1.10.0 |
 
 ## DropdownHeader Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside the DropdownHeader. | | | 1.10.0 |
 
 ## DropdownItem Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | Active | bool | When set to 'true', places the component in the active state with active styling. | | | 1.10.0 |
 | ChildContent | RenderFragment | Specifies the content to be rendered inside the DropdownMenu. | | | 1.10.0 |

--- a/docs/docs/05-components/grid.md
+++ b/docs/docs/05-components/grid.md
@@ -15,7 +15,7 @@ Use Blazor Bootstrap grid component to display tabular data from the data source
 
 ## Grid Parameters
 
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | AllowFiltering | bool | false | | Gets or sets the grid filtering. | 1.0.0 |
 | AllowPaging | bool | false | | Gets or sets the grid paging. | 1.0.0 |
@@ -48,7 +48,7 @@ Grid requires either `Data` or `DataProvider` parameter, but not both.
 
 ## Grid Callback Events
 
-| Name | Type | Descritpion | Added Version |
+| Name | Type | Description | Added Version |
 |:--|:--|:--|:--|
 | GridSettingsChanged | `EventCallback<GridSettings>` | This event is fired when the grid state is changed. | 1.0.0 |
 | OnRowClick | `EventCallback<GridRowEventArgs<TItem>>` | This event is triggered when the user clicks on the row. Set AllowRowClick to true to enable row clicking. | 1.9.5 |
@@ -64,7 +64,7 @@ Grid requires either `Data` or `DataProvider` parameter, but not both.
 
 ## GridColumn Parameters
 
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | | ✔️ | Specifies the content to be rendered inside the grid column. | 1.0.0 |
 | ColumnClass | Func<TItem, string>? | | | Gets or sets the column class. | 1.6.0 |

--- a/docs/docs/05-components/modal.md
+++ b/docs/docs/05-components/modal.md
@@ -13,7 +13,7 @@ Use Blazor Bootstrap modal component to add dialogs to your site for lightboxes,
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |--|--|--|--|--|--|
 | BodyCssClass | string | Additional body CSS class. | | | 1.0.0 |
 | BodyTemplate | RenderFragment | Body template. | ✔️ | | 1.0.0 |

--- a/docs/docs/05-components/offcanvas.md
+++ b/docs/docs/05-components/offcanvas.md
@@ -13,7 +13,7 @@ Build hidden sidebars into your project for navigation, shopping carts, and more
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |--|--|--|--|--|--|
 | BodyCssClass | string | Additional body CSS class. | | | 1.0.0 |
 | BodyTemplate | RenderFragment | Body content. | ✔️ | | 1.0.0 |

--- a/docs/docs/05-components/pagination.md
+++ b/docs/docs/05-components/pagination.md
@@ -13,7 +13,7 @@ Use Blazor Bootstrap pagination component to indicate a series of related conten
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |--|--|--|--|--|
 | ActivePageNumber | int | Active page number. Starts with 1. | | 1 |
 | Alignment | `Alignment` | Gets or sets the pagination alignment. | | `Alignment.None` |

--- a/docs/docs/05-components/placeholders.md
+++ b/docs/docs/05-components/placeholders.md
@@ -13,14 +13,14 @@ Use Blazor Bootstrap loading placeholders for your components or pages to indica
 
 ## PlaceholderContainer Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |--|--|--|--|--|
 | Animation | `PlaceholderAnimation` |  Gets or sets the placeholder animation. | | `PlaceholderAnimation.Glow` |
 | ChildContent | `RenderFragment` | Specifies the content to be rendered inside this. | | |
 
 ## Placeholder Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |--|--|--|--|--|
 | Width | `PlaceholderWidth` | Gets or sets the placeholder width. | | PlaceholderWidth.Col1 |
 | Color | `PlaceholderColor` | Gets or sets the placeholder color. | | PlaceholderColor.None |

--- a/docs/docs/05-components/preload.md
+++ b/docs/docs/05-components/preload.md
@@ -22,7 +22,7 @@ Indicate the loading state of a page with Blazor Bootstrap preload component.
 
 ## Parameters
 
-| Name | Type | Default | Descritpion | Required |  Version Added |
+| Name | Type | Default | Description | Required |  Version Added |
 |--|--|--|--|--|--|
 | ChildContent | RenderFragment | null | Specifies the content to be rendered inside this. | | 1.1.0 |
 

--- a/docs/docs/05-components/progress.md
+++ b/docs/docs/05-components/progress.md
@@ -15,14 +15,14 @@ Documentation and examples for using the Blazor Bootstrap progress component fea
 
 ## Progress Parameters
 
-| Name | Type | Default | Required | Descritpion |
+| Name | Type | Default | Required | Description |
 |:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | | ✔️ | Specifies the content to be rendered inside this. |
 | Height | double | 16 | | Gets or sets the height of the Progress. Height is measured in pixels, and the default height is 16 pixels. |
 
 ## ProgressBar Parameters
 
-| Name | Type | Default | Required | Descritpion |
+| Name | Type | Default | Required | Description |
 |:--|:--|:--|:--|:--|
 | Color| `ProgressColor` | | | Gets or sets the progress color. |
 | Label | string | | | Gets or sets the progress bar label. |

--- a/docs/docs/05-components/sidebar.md
+++ b/docs/docs/05-components/sidebar.md
@@ -15,7 +15,7 @@ Use the Blazor Bootstrap Sidebar component to show consistent cross-browser, res
 
 ## Parameters
 
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | BadgeText | string | | | Gets or sets the badge text. | 1.4.0 |
 | CustomIconName | string | | | Gets or sets the custom icon name. | 1.4.0 |
@@ -33,7 +33,7 @@ Use the Blazor Bootstrap Sidebar component to show consistent cross-browser, res
 
 ## NavItem Properties
 
-| Name | Type | Default | Required | Descritpion | Added Version |
+| Name | Type | Default | Required | Description | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | Class | `string?` | null | | Gets or sets an additional CSS class. | 1.10.3 |
 | CustomIconName | `string?` | null | | Gets or sets the custom icon name. | 1.4.0 |

--- a/docs/docs/05-components/tabs.md
+++ b/docs/docs/05-components/tabs.md
@@ -13,7 +13,7 @@ Documentation and examples for how to use Blazor Bootstrap tabs components.
 
 ## Tabs Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |:--|:--|:--|:--|:--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | | |
 | EnableFadeEffect | bool | Gets or sets the tabs fade effect. | | false |
@@ -30,7 +30,7 @@ Documentation and examples for how to use Blazor Bootstrap tabs components.
 
 ## Tab Parameters
 
-| Name | Type | Descritpion | Required | Default |
+| Name | Type | Description | Required | Default |
 |:--|:--|:--|:--|:--|
 | Title | string | Gets or sets the tab title. | | |
 | TitleTemplate | RenderFragment | Gets or sets the tab title template. | | |

--- a/docs/docs/05-components/toasts.md
+++ b/docs/docs/05-components/toasts.md
@@ -23,7 +23,7 @@ Blazor Toasts are lightweight notifications designed to mimic the push notificat
 
 ## Toasts Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version |
+| Name | Type | Description | Required | Default | Added Version |
 |:--|:--|:--|:--|:--|:--|
 | AutoHide | bool | Auto hide the toast. | | `false` | 1.0.0 |
 | Delay | int | Delay hiding the toast (milli seconds). | | 5000 | 1.0.0 |

--- a/docs/docs/05-components/tooltips.md
+++ b/docs/docs/05-components/tooltips.md
@@ -13,7 +13,7 @@ Use Blazor Bootstrap tooltip component to add custom tooltips to your web pages.
 
 ## Parameters
 
-| Name | Type | Descritpion | Required | Default | Added Version | 
+| Name | Type | Description | Required | Default | Added Version | 
 |--|--|--|--|--|--|
 | ChildContent | RenderFragment | Specifies the content to be rendered inside this. | | | 1.0.0 |
 | Color | `TooltipColor` | Gets or sets the tooltip color. | | `TooltipColor.None` | 1.10.0 |

--- a/docs/docs/06-data-visualization/bar-chart.md
+++ b/docs/docs/06-data-visualization/bar-chart.md
@@ -21,7 +21,7 @@ It is sometimes used to show trend data and to compare multiple data sets side b
 
 ## Methods
 
-| Name | Return type | Descritpion | Added Version |
+| Name | Return type | Description | Added Version |
 |:--|:--|:--|:--|
 | AddDataAsync | `ChartData` | Adds data to bar chart. | 1.10.0 |
 | AddDatasetAsync | `ChartData` | Adds dataset to bar chart. | 1.10.0 |

--- a/docs/docs/06-data-visualization/doughnut-chart.md
+++ b/docs/docs/06-data-visualization/doughnut-chart.md
@@ -21,7 +21,7 @@ It is similar to a pie chart, but the center of the donut chart is hollow. This 
 
 ## Methods
 
-| Name | Return type | Descritpion | Added Version |
+| Name | Return type | Description | Added Version |
 |:--|:--|:--|:--|
 | AddDataAsync | `ChartData` | Adds data to bar chart. | 1.10.0 |
 | AddDatasetAsync | `ChartData` | Adds dataset to bar chart. | 1.10.0 |

--- a/docs/docs/06-data-visualization/line-chart.md
+++ b/docs/docs/06-data-visualization/line-chart.md
@@ -20,7 +20,7 @@ A Blazor Bootstrap line chart component is a graphical representation of data th
 
 ## Methods
 
-| Name | Return type | Descritpion | Added Version |
+| Name | Return type | Description | Added Version |
 |:--|:--|:--|:--|
 | AddDataAsync | `ChartData` | Adds data to bar chart. | 1.10.0 |
 | AddDatasetAsync | `ChartData` | Adds dataset to bar chart. | 1.10.0 |

--- a/docs/docs/06-data-visualization/pie-chart.md
+++ b/docs/docs/06-data-visualization/pie-chart.md
@@ -20,7 +20,7 @@ A Blazor Bootstrap pie chart component is a circular chart that shows the propor
 
 ## Methods
 
-| Name | Return type | Descritpion | Added Version |
+| Name | Return type | Description | Added Version |
 |:--|:--|:--|:--|
 | AddDataAsync | `ChartData` | Adds data to bar chart. | 1.10.0 |
 | AddDatasetAsync | `ChartData` | Adds dataset to bar chart. | 1.10.0 |

--- a/docs/docs/07-services/modal.md
+++ b/docs/docs/07-services/modal.md
@@ -17,7 +17,7 @@ Use Blazor Bootstrap modal service to show quick dialogs to your site for lightb
 
 ## Methods
 
-| Name | Return Type | Descritpion | Added Version |
+| Name | Return Type | Description | Added Version |
 |:--|:--|
 | ShowAsync(**ModalOption** modalOption) | Task | Show the modal. | 1.9.0 |
 


### PR DESCRIPTION
@gvreddy04 Fixed the documentation typo. Related to https://github.com/vikramlearning/blazorbootstrap/issues/392