### PR TITLE
Fix lag in AutoCompleteComponent

### DIFF
--- a/blazorbootstrap/Components/Form/AutoComplete/AutoComplete.razor.cs
+++ b/blazorbootstrap/Components/Form/AutoComplete/AutoComplete.razor.cs
@@ -216,7 +216,7 @@ public partial class AutoComplete<TItem> : BlazorBootstrapComponentBase
         cancellationTokenSource = new CancellationTokenSource();
 
         var token = cancellationTokenSource.Token;
-        await Task.Delay(300, token); // 300ms timeout for the debouncing 
+        
         await FilterDataAsync(token);
 
         closeButton?.HideLoading();


### PR DESCRIPTION
Fixes #407 

Not sure why you've waited here for 300ms on every keystroke. But removing this line fixes the input lage with the component.