### PR TITLE
Remove EditorRequired

### DIFF
--- a/blazorbootstrap/Components/Form/CurrencyInput/CurrencyInput.razor.cs
+++ b/blazorbootstrap/Components/Form/CurrencyInput/CurrencyInput.razor.cs
@@ -448,7 +448,6 @@ public partial class CurrencyInput<TValue> : BlazorBootstrapComponentBase
     /// Gets or sets the locale. Default locale is 'en-US'.
     /// </summary>
     [Parameter]
-    [EditorRequired]
     public string Locale { get; set; } = "en-US";
 
     /// <summary>


### PR DESCRIPTION
This attribute should be removed since a deault value is provided. Otherwise you get nasty warnings everytime you use this component and don't set a locale.