### PR TITLE
Fix #522 by adding ModalType.Default

### DIFF
--- a/blazorbootstrap/Components/Modals/Modal.razor.cs
+++ b/blazorbootstrap/Components/Modals/Modal.razor.cs
@@ -18,7 +18,7 @@ public partial class Modal : BlazorBootstrapComponentBase
 
     private bool isVisible;
 
-    private ModalType modalType = ModalType.Light;
+    private ModalType modalType = ModalType.Default;
 
     private DotNetObjectReference<Modal> objRef = default!;
 

--- a/blazorbootstrap/Enums/ModalType.cs
+++ b/blazorbootstrap/Enums/ModalType.cs
@@ -6,6 +6,10 @@
 public enum ModalType
 {
     /// <summary>
+    /// No color at all.
+    /// </summary>
+    Default,
+    /// <summary>
     /// Primary color.
     /// </summary>
     Primary,

--- a/blazorbootstrap/Utilities/BootstrapClassProvider.cs
+++ b/blazorbootstrap/Utilities/BootstrapClassProvider.cs
@@ -75,7 +75,15 @@ public static class BootstrapClassProvider
 
     public static string Modal { get; } = "modal";
     public static string ModalFade { get; } = Fade;
-    public static string ModalHeader(ModalType modalType) => $"text-bg-{ToModalTypeColor(modalType)} border-bottom {ToModalHeaderBottomBorderColor(modalType)}";
+    public static string ModalHeader(ModalType modalType)
+    {
+        if(modalType is ModalType.Default)
+        {
+            return "border-bottom";
+        }
+
+        return $"text-bg-{ToModalTypeColor(modalType)} border-bottom {ToModalHeaderBottomBorderColor(modalType)}";
+    }
 
     public static string Nav { get; } = "nav";
     public static string NavPills { get; } = $"{Nav}-pills";


### PR DESCRIPTION
I came accross #522 in my application as well.

The issue is that the default `ModalType` is set to `ModalType.Light` which results in a `data-bs-theme='light'` modal header everytime except when you explicitly define `ModalType.Dark`.

This PR fixes this behaviour by adding a new `ModalType.Default` which is the new default value from now on. 
