### PR TITLE
Update ribbon docs - fix copy/paste miss

### DIFF
--- a/docs/docs/05-components/ribbon.mdx
+++ b/docs/docs/05-components/ribbon.mdx
@@ -9,7 +9,7 @@ sidebar_position: 20
 
 import CarbonAd from '/carbon-ad.mdx'
 
-# Blazor Progress
+# Blazor Ribbon
 
 Documentation and examples for using the Blazor Bootstrap Ribbon component.
 


### PR DESCRIPTION
I noticed what I think is a copy/paste error in the documentation this morning :)