### PR TITLE
Pr chartjs plugins

### DIFF
--- a/BlazorBootstrap.Demo.RCL/Components/Pages/Charts/LineCharts/LineChartDocumentation.razor
+++ b/BlazorBootstrap.Demo.RCL/Components/Pages/Charts/LineCharts/LineChartDocumentation.razor
@@ -6,24 +6,24 @@
 
 <h1>Blazor Line Chart</h1>
 <div class="lead mb-3">
-    A Blazor Bootstrap line chart component is a graphical representation of data that uses a series of connected points to show how the data changes over time.
-    It is a type of x-y chart, where the x-axis represents the independent variable, such as time, and the y-axis represents the dependent variable, such as the value.
+  A Blazor Bootstrap line chart component is a graphical representation of data that uses a series of connected points to show how the data changes over time.
+  It is a type of x-y chart, where the x-axis represents the independent variable, such as time, and the y-axis represents the dependent variable, such as the value.
 </div>
 
 <CarbonAds />
 
 <SectionHeading Size="HeadingSize.H4" Text="Prerequisites" PageUrl="@pageUrl" HashTagName="prerequisites" />
 <div class="mb-3">
-    Refer to the <a href="/getting-started/blazor-webassembly">getting started guide</a> for setting up charts.
+  Refer to the <a href="/getting-started/blazor-webassembly">getting started guide</a> for setting up charts.
 </div>
 
 <SectionHeading Size="HeadingSize.H4" Text="How it works" PageUrl="@pageUrl" HashTagName="how-it-works" />
 <div class="mb-3">
-    In the following example, a <a href="/utils/color-utility#categorical-12-color">categorical 12-color</a> palette is used.
+  In the following example, a <a href="/utils/color-utility#categorical-12-color">categorical 12-color</a> palette is used.
 </div>
 <Callout Heading="TIP" Color="CalloutColor.Success">
-    For data visualization, you can use the predefined palettes <code>ColorUtility.CategoricalTwelveColors</code> for a 12-color palette and <code>ColorUtility.CategoricalSixColors</code> for a 6-color palette.
-    These palettes offer a range of distinct and visually appealing colors that can be applied to represent different categories or data elements in your visualizations.
+  For data visualization, you can use the predefined palettes <code>ColorUtility.CategoricalTwelveColors</code> for a 12-color palette and <code>ColorUtility.CategoricalSixColors</code> for a 6-color palette.
+  These palettes offer a range of distinct and visually appealing colors that can be applied to represent different categories or data elements in your visualizations.
 </Callout>
 <Demo Type="typeof(LineChart_Demo_01_A_Examples)" Tabs="true" />
 <div class="my-3"></div>
@@ -31,8 +31,8 @@
 
 <SectionHeading Size="HeadingSize.H4" Text="Locale" PageUrl="@pageUrl" HashTagName="locale" />
 <div class="my-3">
-    By default, the chart is using the default locale of the platform on which it is running.
-    In the following example, you will see the chart in the <b>German</b> locale (<b>de_DE</b>).
+  By default, the chart is using the default locale of the platform on which it is running.
+  In the following example, you will see the chart in the <b>German</b> locale (<b>de_DE</b>).
 </div>
 <Demo Type="typeof(LineChart_Demo_02_Locale)" Tabs="true" />
 
@@ -48,9 +48,12 @@
 <SectionHeading Size="HeadingSize.H4" Text="Fill between datasets" PageUrl="@pageUrl" HashTagName="dataset-fill" />
 <Demo Type="typeof(LineChart_Demo_06_Dataset_Fill)" Tabs="true" />
 
+<SectionHeading Size="HeadingSize.H4" Text="(Custom) Plugins" PageUrl="@pageUrl" HashTagName="plugins" />
+<Demo Type="typeof(LineChart_Demo_08_Plugins)" Tabs="true" />
+
 @code {
-    private readonly string pageUrl = "/charts/line-chart";
-    private readonly string title = "Blazor Line Chart";
-    private readonly string description = "A Blazor Bootstrap line chart component is a graphical representation of data that uses a series of connected points to show how the data changes over time. It is a type of x-y chart, where the x-axis represents the independent variable, such as time, and the y-axis represents the dependent variable, such as the value.";
-    private readonly string imageUrl = "https://i.imgur.com/8b7jH0D.png";
+  private readonly string pageUrl = "/charts/line-chart";
+  private readonly string title = "Blazor Line Chart";
+  private readonly string description = "A Blazor Bootstrap line chart component is a graphical representation of data that uses a series of connected points to show how the data changes over time. It is a type of x-y chart, where the x-axis represents the independent variable, such as time, and the y-axis represents the dependent variable, such as the value.";
+  private readonly string imageUrl = "https://i.imgur.com/8b7jH0D.png";
 }

--- a/BlazorBootstrap.Demo.RCL/Components/Pages/Charts/LineCharts/LineChart_Demo_08_Plugins.razor
+++ b/BlazorBootstrap.Demo.RCL/Components/Pages/Charts/LineCharts/LineChart_Demo_08_Plugins.razor
@@ -1,0 +1,203 @@
+﻿@using System.Text.Json.Serialization
+<div class="container-fluid overflow-x-auto">
+  <LineChart @ref="lineChart" Width="800" />
+</div>
+<small>This line chart has the Zoom (built-in), Annotations (built-in), DragData (locally defined) and Crosshair (anonymous) plugins enabled.</small>
+
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3/dist/chartjs-plugin-annotation.min.js" integrity="sha256-8BDDxChCyYOB80/6VhOpmr7qI5EIDyDPzxsWePPFVfo=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-crosshair@2/dist/chartjs-plugin-crosshair.min.js" integrity="sha256-5bTtdEYtbjO36pQbMCXOsoYW5u5jfYfyI41LelMTTbQ=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2/dist/chartjs-plugin-zoom.min.js" integrity="sha256-UDxwmAK+KFxnav4Dab9fcgZtCwwjkpGIwxWPNcAyepw=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-dragdata@2/dist/chartjs-plugin-dragdata.min.js" integrity="sha256-TVzMefO8VbXaQ5GV1xGhZbFEGUGOm/x/y7bQGhxyKuE=" crossorigin="anonymous"></script>
+
+@code {
+  private LineChart lineChart = default!;
+  private LineChartOptions lineChartOptions = default!;
+  private ChartData chartData = default!;
+
+  protected override void OnInitialized()
+  {
+    var colors = ColorUtility.CategoricalTwelveColors;
+    var labels = new List<string> { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
+    var datasets = new List<IChartDataset>();
+
+    var dataset1 = new LineChartDataset
+      {
+        Label = "Windows",
+        Data = new List<double?> { 7265791, 5899643, 6317759, 6315641, 5338211, 8496306, 7568556, 8538933, 8274297, 8657298, 7548388, 7764845 },
+        BorderWidth = 2,
+        HoverBorderWidth = 4,
+        BackgroundColor = colors[ 0 ],
+        BorderColor = colors[ 0 ],
+      };
+    datasets.Add( dataset1 );
+
+    var dataset2 = new LineChartDataset
+      {
+        Label = "macOS",
+        Data = new List<double?> { 1809499, 1816642, 2122410, 1809499, 1850793, 1846743, 1954797, 2391313, 1983430, 2469918, 2633303, 2821149 },
+        BorderWidth = 2,
+        HoverBorderWidth = 4,
+        BackgroundColor = colors[ 1 ],
+        BorderColor = colors[ 1 ],
+      };
+    datasets.Add( dataset2 );
+
+    var dataset3 = new LineChartDataset
+      {
+        Label = "Other",
+        Data = new List<double?> { 1081241, 1100363, 1118136, 1073255, 1120315, 1395736, 1488788, 1489466, 1489947, 1414739, 1735811, 1820171 },
+        BorderWidth = 2,
+        HoverBorderWidth = 4,
+        BackgroundColor = colors[ 2 ],
+        BorderColor = colors[ 2 ],
+      };
+    datasets.Add( dataset3 );
+
+    chartData = new ChartData { Labels = labels, Datasets = datasets };
+
+    lineChartOptions = new();
+    lineChartOptions.Responsive = true;
+    lineChartOptions.Interaction = new Interaction { Mode = InteractionMode.Index };
+
+    lineChartOptions.Scales.X!.Title = new ChartAxesTitle { Text = "2019", Display = true };
+    lineChartOptions.Scales.Y!.Title = new ChartAxesTitle { Text = "Visitors", Display = true };
+
+    lineChartOptions.Plugins.Title!.Text = "Operating system";
+    lineChartOptions.Plugins.Title.Display = true;
+
+    EnableDragDataPlugin();
+    EnableZoomPlugin();
+    EnableAnnotationsPlugin();
+    EnableCrosshairsPlugin();
+  }
+
+  [JsonSourceGenerationOptions( DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase )]
+  public class DragDataPlugin : ChartPlugin
+  {
+    public bool? DragX { get; set; }
+    public bool? DragY { get; set; }
+    public bool? ShowTooltip { get; set; }
+  }
+
+  private void EnableDragDataPlugin()
+  {
+    // Example of a plugin class deriving from ChartPlugin that is defined locally
+    lineChartOptions.Plugins.Add( "dragData", new DragDataPlugin() { DragX = true, ShowTooltip = false } );
+
+    // Alternative way to access the plugin:
+    var plugin = lineChartOptions.Plugins.Get<DragDataPlugin>();
+    plugin.ShowTooltip = true;
+  }
+
+  private void EnableAnnotationsPlugin()
+  {
+    // Example of the built-in Annotation plugin class.
+    var annotations = new ChartPluginsAnnotation()
+      {
+        Annotations = new List<Annotation>()
+      };
+
+    foreach( LineChartDataset dataset in chartData.Datasets )
+    {
+      var average = dataset.Data.Average();
+      annotations.Annotations.Add( new LineAnnotation()
+        {
+          BorderColor = dataset.BorderColor,
+          BorderDash = [ 2, 2 ],
+          YMin = average,
+          YMax = average
+        } );
+    }
+
+    annotations.Annotations.Add( new BoxAnnotation()
+      {
+        XMin = 3.5,
+        XMax = 8.75,
+        YMin = 1250000,
+        YMax = 4750000,
+        BorderWidth = 2,
+        BorderColor = "gray",
+        BorderDash = [ 1, 1 ],
+        BackgroundColor = "rgba(255, 255, 0, 0.1)",
+        ShadowOffsetX = 5,
+        ShadowOffsetY = 5
+      } );
+
+    lineChartOptions.Plugins.Add( "annotation", annotations );
+  }
+
+  private void EnableZoomPlugin()
+  {
+    // Example of the built-in Zoom plugin class.
+    var zoom = new ChartPluginsZoom()
+      {
+        Zoom = new()
+        {
+          Wheel = new()
+          {
+            Enabled = true
+          },
+          Pinch = new()
+          {
+            Enabled = true
+          },
+          Mode = ZoomMode.Y,
+          ScaleMode = ZoomMode.XY,
+        },
+        Pan = new()
+        {
+          Enabled = true,
+          Mode = ZoomMode.XY
+        },
+        Limits = new()
+        {
+          X = new() { MinimumIsOriginal = true, MaximumIsOriginal = true, MinRange = 1.0 },
+          Y = new() { MinimumIsOriginal = true, MaximumIsOriginal = true, MinRange = 1.0 }
+        }
+      };
+
+    lineChartOptions.Plugins.Add( "zoom", zoom );
+  }
+
+  private void EnableCrosshairsPlugin()
+  {
+    // Example of an anonymous plugin class, i.e. one that does not derive from ChartPlugin.
+    // Note that you cannot .Get() or .TryGet() it later.
+    // Demo configuration taken directly from https://github.com/abelheinsbroek/chartjs-plugin-crosshair
+    var crossHairs = new
+    {
+      line = new
+      {
+        color = "#F66",
+        width = 1,
+      },
+      sync = new
+      {
+        enabled = true,
+        group = 1,
+        suppressTooltips = false
+      },
+      zoom = new
+      {
+        enabled = true,
+        zoomboxBackgroundColor = "rgba(66,133,244,0.2)",
+        zoomboxBorderColor = "#48F",
+        zoomButtonText = "Reset Zoom",
+        zoomButtonClass = "reset-zoom",
+      }
+    };
+
+    lineChartOptions.Plugins.AddObject( "crosshairs", crossHairs );
+  }
+
+
+  protected override async Task OnAfterRenderAsync( bool firstRender )
+  {
+    if( firstRender )
+    {
+      await lineChart.InitializeAsync( chartData, lineChartOptions );
+    }
+    await base.OnAfterRenderAsync( firstRender );
+  }
+
+}

--- a/blazorbootstrap/Enums/DrawTime.cs
+++ b/blazorbootstrap/Enums/DrawTime.cs
@@ -1,0 +1,24 @@
+﻿namespace BlazorBootstrap;
+
+public enum DrawTime
+{
+  /// <summary>
+  /// Occurs before any drawing takes place
+  /// </summary>
+  BeforeDraw,
+
+  /// <summary>
+  /// Occurs after drawing of axes, but before datasets
+  /// </summary>
+  BeforeDatasetsDraw,
+
+  /// <summary>
+  /// Occurs after drawing of datasets but before items such as the tooltip
+  /// </summary>
+  AfterDatasetsDraw,
+
+  /// <summary>
+  /// After other drawing is completed.
+  /// </summary>
+  AfterDraw
+}

--- a/blazorbootstrap/Enums/PointStyle.cs
+++ b/blazorbootstrap/Enums/PointStyle.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlazorBootstrap;
+
+public enum PointStyle
+{
+  Circle,
+  Cross,
+  CrossRot,
+  Dash,
+  Line,
+  Rect,
+  RectRounded,
+  RectRot,
+  Star,
+  Triangle
+}

--- a/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.Annotations.cs
+++ b/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.Annotations.cs
@@ -1,0 +1,671 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlazorBootstrap;
+
+public abstract class Annotation
+{
+  /// <summary>
+  /// The type of the annotation
+  /// </summary>
+  public abstract string Type { get; }
+
+  ///<summary>
+  /// TRUE
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? AdjustScaleRange { get; set; }
+  ///<summary>
+  /// options.color
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BackgroundColor { get; set; }
+  ///<summary>
+  /// options.color
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderColor { get; set; }
+  ///<summary>
+  /// []
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public List<double?>? BorderDash { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderDashOffset { get; set; }
+  ///<summary>
+  /// 'transparent'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderShadowColor { get; set; }
+  ///<summary>
+  /// TRUE
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Display { get; set; }
+  ///<summary>
+  /// 'afterDatasetsDraw'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public DrawTime? DrawTime { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Init { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Id { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? ShadowBlur { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? ShadowOffsetX { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? ShadowOffsetY { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? XMax { get; set; }
+
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? XMin { get; set; }
+
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? XScaleID { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? YMin { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? YMax { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? YScaleID { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Z { get; set; }
+
+}
+
+public class LineAnnotation : Annotation
+{
+  public override string Type => "line";
+
+  /// <summary>
+  /// The border width, defaults to 2.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+
+  /// <summary>
+  /// Whether or not a quadratic Bézier curve is drawn.
+  /// Defaults to <see langword=false/>
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Curve { get; set; }
+
+  /// <summary>
+  /// End two of the line when a single scale is specified.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? EndValue { get; set; }
+
+  /// <summary>
+  /// Defines options for the line annotation label.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartAnnotationLabel? Label { get; set; }
+
+  /// <summary>
+  /// ID of the scale in single scale mode. If unset, xScaleID and yScaleID are used.
+  /// If scaleID is set, then value and endValue must also be set to indicate the endpoints of the line. The 
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? ScaleID { get; set; }
+
+  /// <summary>
+  /// End one of the line when a single scale is specified.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Value { get; set; }
+
+  /// <summary>
+  /// If curve is enabled, it configures the control point to drawn the curve, calculated in pixels. 
+  /// It can be set by a string in percentage format 'number%' which are representing the percentage of the distance between the start and end point from the center.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? ControlPoint { get; set; }
+
+}
+
+public class ChartAnnotationLabel
+{
+  ///<summary>
+  /// Background color of the label container.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string BackgroundColor { get; set; }
+
+  ///<summary>
+  /// The color of shadow of the box where the label is located. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string BackgroundShadowColor { get; set; }
+
+  ///<summary>
+  /// Cap style of the border.
+  /// Supported values are 'butt', 'round', and 'square'.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderCapStyle { get; set; }
+
+  ///<summary>
+  /// The border line color.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderColor { get; set; }
+
+  ///<summary>
+  /// Length and spacing of dashes. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public List<double>? BorderDash { get; set; }
+
+  ///<summary>
+  /// Offset for border line dashes. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderDashOffset { get; set; }
+
+  ///<summary>
+  /// Border line join style. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderJoinStyle { get; set; }
+
+  ///<summary>
+  /// Radius of label box corners in pixels.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderRadius { get; set; }
+
+  ///<summary>
+  /// The color of border shadow of the box where the label is located. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderShadowColor { get; set; }
+
+  ///<summary>
+  /// The border line width (in pixels).
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+
+  ///<summary>
+  /// Text color.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public List<string?>? Color { get; set; }
+
+  ///<summary>
+  /// The content to show in the label
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string Content { get; set; }
+
+  ///<summary>
+  /// Whether or not the label is shown.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Display { get; set; }
+
+  ///<summary>
+  /// See drawTime. Defaults to the line annotation draw time if unset.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public DrawTime? DrawTime { get; set; }
+
+  ///<summary>
+  /// Label font.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Font { get; set; }
+
+  ///<summary>
+  /// Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? Height { get; set; }
+
+  ///<summary>
+  /// Overrides the opacity of the image or canvas element. Could be set a number in the range 0.0 to 1.0, inclusive. If undefined, uses the opacity of the image or canvas element. It is used only when the content is an image or canvas element.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Opacity { get; set; }
+
+  ///<summary>
+  /// The padding to add around the text label.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Padding { get; set; }
+
+  ///<summary>
+  /// Anchor position of label on line. Possible options are: 'start', 'center', 'end'. It can be set by a string in percentage format 'number%' which are representing the percentage on the width of the line where the label will be located.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public Alignment? Position { get; set; }
+
+  ///<summary>
+  /// Rotation of label, in degrees, or 'auto' to use the degrees of the line.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Rotation { get; set; }
+
+  ///<summary>
+  /// The amount of blur applied to shadow of the box where the label is located. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? ShadowBlur { get; set; }
+
+  ///<summary>
+  /// The distance that shadow, of the box where the label is located, will be offset horizontally. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? ShadowOffsetX { get; set; }
+
+  ///<summary>
+  /// The distance that shadow, of the box where the label is located, will be offset vertically. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? ShadowOffsetY { get; set; }
+
+  ///<summary>
+  /// Text alignment of label content when there's more than one line. Possible options are: 'start', 'center', 'end'.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public TitleAlignment? TextAlign { get; set; }
+
+  ///<summary>
+  /// The color of the stroke around the text.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? TextStrokeColor { get; set; }
+
+  ///<summary>
+  /// Stroke width around the text.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? TextStrokeWidth { get; set; }
+
+  ///<summary>
+  /// Overrides the width of the image or canvas element. Could be set in pixel by a number, or in percentage of current width of image or canvas element by a string. If undefined, uses the width of the image or canvas element. It is used only when the content is an image or canvas element.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? Width { get; set; }
+
+  ///<summary>
+  /// Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? XAdjust { get; set; }
+
+  ///<summary>
+  /// Adjustment along y-axis (top-bottom) of label relative to computed position. Negative values move the label up, positive down.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? YAdjust { get; set; }
+
+  ///<summary>
+  /// It determines the drawing stack level of the label element, with same drawTime.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Z { get; set; }
+
+
+}
+
+public class BoxAnnotation : Annotation
+{
+  public override string Type => "box";
+
+  ///<summary>
+  /// 'transparent'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BackgroundShadowColor { get; set; }
+  ///<summary>
+  /// 'butt'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderCapStyle { get; set; }
+  ///<summary>
+  /// 'miter'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderJoinStyle { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? BorderRadius { get; set; }
+  ///<summary>
+  /// 1
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+  ///<summary>
+  /// 
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartAnnotationLabel? Label { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Rotation { get; set; }
+}
+
+
+public class EllipseAnnotation : Annotation
+{
+  public override string Type => "ellipse";
+
+  ///<summary>
+  /// 'transparent'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BackgroundShadowColor { get; set; }
+  ///<summary>
+  /// 1
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+  ///<summary>
+  /// 
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartAnnotationLabel? label { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Rotation { get; set; }
+}
+
+public class LabelAnnotation : Annotation
+{
+  public override string Type => "label";
+
+  ///<summary>
+  /// The color of shadow of the box where the label is located. See MDN
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string BackgroundShadowColor { get; set; }
+
+  ///<summary>
+  /// Cap style of the border.
+  /// Supported values are 'butt', 'round', and 'square'.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderCapStyle { get; set; }
+
+  ///<summary>
+  /// 'miter'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderJoinStyle { get; set; }
+
+  ///<summary>
+  /// Radius of label box corners in pixels.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderRadius { get; set; }
+
+  ///<summary>
+  /// The border line width (in pixels).
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+
+  ///<summary>
+  /// Text color.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public List<string?>? Color { get; set; }
+
+  ///<summary>
+  /// The content to show in the label
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string Content { get; set; }
+
+  ///<summary>
+  /// Label font.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Font { get; set; }
+
+  ///<summary>
+  /// Overrides the height of the image or canvas element. Could be set in pixel by a number, or in percentage of current height of image or canvas element by a string. If undefined, uses the height of the image or canvas element. It is used only when the content is an image or canvas element.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? Height { get; set; }
+
+  ///<summary>
+  /// Overrides the opacity of the image or canvas element. Could be set a number in the range 0.0 to 1.0, inclusive. If undefined, uses the opacity of the image or canvas element. It is used only when the content is an image or canvas element.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Opacity { get; set; }
+
+  ///<summary>
+  /// The padding to add around the text label.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Padding { get; set; }
+
+  ///<summary>
+  /// Anchor position of label on line. Possible options are: 'start', 'center', 'end'. It can be set by a string in percentage format 'number%' which are representing the percentage on the width of the line where the label will be located.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public Alignment? Position { get; set; }
+
+  ///<summary>
+  /// Rotation of label, in degrees, or 'auto' to use the degrees of the line.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Rotation { get; set; }
+
+  ///<summary>
+  /// Text alignment of label content when there's more than one line. Possible options are: 'start', 'center', 'end'.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public TitleAlignment? TextAlign { get; set; }
+
+  ///<summary>
+  /// The color of the stroke around the text.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? TextStrokeColor { get; set; }
+
+  ///<summary>
+  /// Stroke width around the text.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? TextStrokeWidth { get; set; }
+
+  ///<summary>
+  /// Overrides the width of the image or canvas element. Could be set in pixel by a number, or in percentage of current width of image or canvas element by a string. If undefined, uses the width of the image or canvas element. It is used only when the content is an image or canvas element.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? Width { get; set; }
+
+  ///<summary>
+  /// Adjustment along x-axis (left-right) of label relative to computed position. Negative values move the label left, positive right.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? XAdjust { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? XValue { get; set; }
+
+  ///<summary>
+  /// Adjustment along y-axis (top-bottom) of label relative to computed position. Negative values move the label up, positive down.
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? YAdjust { get; set; }
+
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? YValue { get; set; }
+}
+
+
+public class PointAnnotation : Annotation
+{
+  public override string Type => "point";
+
+  ///<summary>
+  /// 'transparent'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BackgroundShadowColor { get; set; }
+  ///<summary>
+  /// 1
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+  ///<summary>
+  /// 'circle'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public PointStyle? PointStyle { get; set; }
+  ///<summary>
+  /// 10
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Radius { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Rotation { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? XAdjust { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? XValue { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? YAdjust { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? YValue { get; set; }
+}
+
+public class PolygonAnnotation : Annotation
+{
+  public override string Type => "polygon";
+
+  ///<summary>
+  /// 'transparent'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BackgroundShadowColor { get; set; }
+  ///<summary>
+  /// 'butt'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderCapStyle { get; set; }
+  ///<summary>
+  /// 'miter'
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderJoinStyle { get; set; }
+  ///<summary>
+  /// 1
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+  ///<summary>
+  /// {radius: 0}
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public PointAnnotation? Point { get; set; }
+  ///<summary>
+  /// 10
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Radius { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Rotation { get; set; }
+  ///<summary>
+  /// 3
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Sides { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? XAdjust { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? XValue { get; set; }
+  ///<summary>
+  /// 0
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? YAdjust { get; set; }
+  ///<summary>
+  /// undefined
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public object? YValue { get; set; }
+
+}
+

--- a/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.Zoom.cs
+++ b/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.Zoom.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlazorBootstrap;
+
+public enum ZoomMode
+{
+  None,
+  X,
+  Y,
+  XY
+}
+
+public enum ModifierKey
+{
+  None,
+  Ctrl,
+  Alt,
+  Shift,
+  Meta
+}
+
+public class ZoomLimitAxisOptions
+{
+  /// <summary>
+  /// Minimum allowed value for scale.min
+  /// </summary>
+  [JsonIgnore]
+  public double? Min { get; set; }
+
+  [JsonIgnore]
+  public bool? MinimumIsOriginal { get; set; }
+
+  [JsonInclude]
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonPropertyName( "min" )]
+  private string? minText => MinimumIsOriginal.GetValueOrDefault() ? "original" : Min?.ToString();
+
+  /// <summary>
+  /// Maximum allowed value for scale.max
+  /// </summary>
+  [JsonIgnore]
+  public double? Max { get; set; }
+
+  [JsonIgnore]
+  public bool? MaximumIsOriginal { get; set; }
+
+  [JsonInclude]
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonPropertyName( "max" )]
+  private string? maxText => MaximumIsOriginal.GetValueOrDefault() ? "original" : Max?.ToString();
+
+  /// <summary>
+  /// Minimum allowed range (max - min). This defines the max zoom level.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonPropertyName( "minRange" )]
+  public double? MinRange { get; set; }
+}
+
+public class DragOptions
+{
+  ///<summary>
+  /// Enable drag-to-zoom
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Enabled { get; set; }
+
+  ///<summary>
+  /// Fill color
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BackgroundColor { get; set; }
+
+  ///<summary>
+  /// Stroke color
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? BorderColor { get; set; }
+
+  ///<summary>
+  /// Stroke width
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? BorderWidth { get; set; }
+
+  ///<summary>
+  /// When the dragging box is dran on the chart
+  /// <summary>
+  [JsonIgnore]
+  public DrawTime? DrawTime { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "drawTime" )]
+  private string? DrawTimeText => DrawTime?.ToString().ToLower();
+
+  ///<summary>
+  /// Minimal zoom distance required before actually applying zoom
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Threshold { get; set; }
+
+  ///<summary>
+  /// Modifier key required for drag-to-zoom
+  /// <summary>
+  [JsonIgnore]
+  public ModifierKey? ModifierKey { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "modifierKey" )]
+  private string? ModifierKeyText => ( ModifierKey == BlazorBootstrap.ModifierKey.None ) ? string.Empty : ModifierKey?.ToString().ToLower();
+}
+
+public class PinchOptions
+{
+  ///<summary>
+  ///      /// Enable zooming via pinch gesture
+  ///           /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Enabled { get; set; }
+}
+
+public class PanOptions
+{///<summary>
+ /// Enable panning
+ /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Enabled { get; set; }
+
+  ///<summary>
+  /// Allowed panning directions
+  /// <summary>
+  [JsonIgnore]
+  public ZoomMode? Mode { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "mode" )]
+  private string? ModeText => ( Mode == ZoomMode.None ) ? string.Empty : Mode?.ToString().ToLower();
+
+  ///<summary>
+  /// Modifier key required for panning with mouse
+  /// <summary>
+  [JsonIgnore]
+  public ModifierKey? ModifierKey { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "modifierKey" )]
+  private string? ModifierKeyText => ( ModifierKey == BlazorBootstrap.ModifierKey.None ) ? string.Empty : ModifierKey?.ToString().ToLower();
+
+  ///<summary>
+  /// Enable panning over a scale for that axis (regardless of mode)
+  /// <summary>
+  [JsonIgnore]
+  public ZoomMode? ScaleMode { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "scaleMode" )]
+  private string? ScaleModeText => ( ScaleMode == ZoomMode.None ) ? string.Empty : ScaleMode?.ToString().ToLower();
+
+  ///<summary>
+  /// Enable panning over a scale for that axis (but only if mode is also enabled), and disables panning along that axis otherwise. Deprecated.
+  /// <summary>
+  [JsonIgnore]
+  public ZoomMode? OverScaleMode { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "overScaleMode" )]
+  private string? OverScaleModeText => ( OverScaleMode == ZoomMode.None ) ? string.Empty : OverScaleMode?.ToString().ToLower();
+
+  ///<summary>
+  /// Minimal pan distance required before actually applying pan
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Threshold { get; set; }
+}
+
+public class ZoomLimitOptions
+{
+  public ZoomLimitAxisOptions X { get; set; } = new();
+  public ZoomLimitAxisOptions Y { get; set; } = new();
+
+}
+
+public class ZoomOptions
+{
+  ///<summary>
+  /// Options of the mouse wheel behavior
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public WheelOptions? Wheel { get; set; }
+
+  ///<summary>
+  /// Options of the drag-to-zoom behavior
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public DragOptions? Drag { get; set; }
+
+  ///<summary>
+  /// Options of the pinch behavior
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public PinchOptions? Pinch { get; set; }
+
+  ///<summary>
+  /// Allowed zoom directions
+  /// <summary>
+  [JsonIgnore]
+  public ZoomMode? Mode { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "mode" )]
+  private string? ModeText => ( Mode == ZoomMode.None ) ? string.Empty : Mode?.ToString().ToLower();
+
+  ///<summary>
+  /// Which of the enabled zooming directions should only be available when the mouse cursor is over a scale for that axis
+  /// <summary>
+  [JsonIgnore]
+  public ZoomMode? ScaleMode { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "scaleMode" )]
+  private string? ScaleModeText => ( ScaleMode == ZoomMode.None ) ? string.Empty : ScaleMode?.ToString().ToLower();
+
+  ///<summary>
+  /// Allowed zoom directions when the mouse cursor is over a scale for that axis (but only if mode is also enabled), and disables zooming along that axis otherwise. Deprecated; use scaleMode instead.
+  /// <summary>
+  [JsonIgnore]
+  public ZoomMode? OverScaleMode { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "overScaleMode" )]
+  private string? OverScaleModeText => ( OverScaleMode == ZoomMode.None ) ? string.Empty : OverScaleMode?.ToString().ToLower();
+
+}
+
+public class WheelOptions
+{
+  ///<summary>
+  /// Enable zooming via mouse wheel
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Enabled { get; set; }
+
+  ///<summary>
+  /// Factor of zoom speed via mouse wheel
+  /// <summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public double? Speed { get; set; }
+
+  ///<summary>
+  /// Modifier key required for zooming via mouse wheel
+  /// <summary>
+  [JsonIgnore]
+  public ModifierKey? ModifierKey { get; set; }
+
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  [JsonInclude]
+  [JsonPropertyName( "modifierKey" )]
+  private string? ModifierKeyText => ( ModifierKey == BlazorBootstrap.ModifierKey.None ) ? string.Empty : ModifierKey?.ToString().ToLower();
+}

--- a/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
+++ b/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
@@ -19,6 +19,11 @@ public class ChartPlugins
 
   #region Methods
 
+  public void AddObject( string key, object plugin )
+  {
+    customPlugins.Add( key, plugin );
+  }
+
   public void Add<T>( string key, T plugin )
     where T : ChartPlugin
   {
@@ -86,7 +91,7 @@ public class ChartPlugins
   #endregion
 }
 
-public class ChartPluginsAnnotation
+public class ChartPluginsAnnotation : ChartPlugin
 {
   #region Inner classes
 
@@ -139,7 +144,6 @@ public class ChartPluginsAnnotation
 
   #endregion
 }
-
 public class ChartPluginsLegend : ChartPlugin
 {
   #region Properties, Indexers

--- a/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
+++ b/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
@@ -483,3 +483,16 @@ public class ChartPluginsTooltipFont : ChartPlugin
 
   #endregion
 }
+
+/// <summary>
+/// Configuration for the Zoom plugin, if enabled.
+/// See <see href="https://www.chartjs.org/chartjs-plugin-zoom/latest/guide/" />
+/// </summary>
+public class ChartPluginsZoom : ChartPlugin
+{
+  public ZoomLimitOptions? Limits { get; set; }
+
+  public PanOptions? Pan { get; set; }
+
+  public ZoomOptions? Zoom { get; set; }
+}

--- a/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
+++ b/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
@@ -86,6 +86,60 @@ public class ChartPlugins
   #endregion
 }
 
+public class ChartPluginsAnnotation
+{
+  #region Inner classes
+
+  public class ChartPluginsAnnotationsCommon
+  {
+    #region Properties, Indexers
+
+    /// <summary>
+    /// Determines where in the chart lifecycle the drawing occurs. Defaults to <c>afterDatasetsDraw</c>
+    /// </summary
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public DrawTime? DrawTime { get; set; }
+
+    /// <summary>
+    /// Enable the animation to the annotations when they are drawing at chart initialization. Defaults to <see langword="false"/>.
+    /// </summary
+    [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+    public bool? Init { get; set; }
+
+    #endregion
+  }
+
+  #endregion
+
+  #region Properties, Indexers
+
+  /// <summary>
+  /// Are the annotations clipped to the chartArea? Defaults to <see langword="true"/>.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public bool? Clip { get; set; }
+
+  /// <summary>
+  /// Configure common options apply to all annotations
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartPluginsAnnotationsCommon? Common { get; set; }
+
+  /// <summary>
+  /// To configure which events trigger plugin interactions.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public Interaction? Interaction { get; set; }
+
+  /// <summary>
+  /// The annotations for this chart
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public List<Annotation>? Annotations { get; set; }
+
+  #endregion
+}
+
 public class ChartPluginsLegend : ChartPlugin
 {
   #region Properties, Indexers

--- a/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
+++ b/blazorbootstrap/Models/Charts/ChartPlugins/ChartPlugins.cs
@@ -1,186 +1,244 @@
-﻿namespace BlazorBootstrap;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace BlazorBootstrap;
+
+public abstract class ChartPlugin { }
 
 public class ChartPlugins
 {
-    #region Properties, Indexers
+  #region Fields
 
-    /// <summary>
-    /// The chart legend displays data about the datasets that are appearing on the chart.
-    /// </summary>
-    public ChartPluginsLegend Legend { get; set; } = new();
+  [JsonInclude]
+  [JsonExtensionData]
+  private Dictionary<string, object> customPlugins = new();
 
-    /// <summary>
-    /// The chart title defines text to draw at the top of the chart.
-    /// <see href="https://www.chartjs.org/docs/latest/configuration/title.html"/> 
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartPluginsTitle? Title { get; set; } = new();
+  [JsonIgnore]
+  private Dictionary<Type, ChartPlugin> customPluginsByType = new();
 
-    /// <summary>
-    /// Tooltip for the element.
-    /// <see href="https://www.chartjs.org/docs/latest/configuration/tooltip.html"/>
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartPluginsTooltip? Tooltip { get; set; }
-    
+  #endregion
 
+  #region Methods
 
-    #endregion
+  public void Add<T>( string key, T plugin )
+    where T : ChartPlugin
+  {
+    customPlugins.Add( key, plugin );
+    customPluginsByType.Add( typeof( T ), plugin );
+  }
+
+  public bool TryAdd<T>( string key, ChartPlugin plugin )
+    where T : ChartPlugin
+      => customPlugins.TryAdd( key, plugin ) && customPluginsByType.TryAdd( typeof( T ), plugin );
+
+  public T Get<T>( string key ) where T : ChartPlugin
+    => (T)customPlugins[ key ];
+
+  public T? Get<T>() where T : ChartPlugin
+    => customPluginsByType.TryGetValue( typeof( T ), out var plugin ) ? (T)plugin : null;
+
+  public bool TryGet<T>( string key, [NotNullWhen( true )] out T? value ) where T : ChartPlugin
+  {
+    value = null;
+    if( customPlugins.TryGetValue( key, out var plugin ) && ( plugin is T pluginAsT ) )
+    {
+      value = pluginAsT;
+      return true;
+    }
+
+    return false;
+  }
+
+  public bool TryGet<T>( [NotNullWhen( true )] out T? value ) where T : ChartPlugin
+  {
+    value = null;
+    if( customPluginsByType.TryGetValue( typeof( T ), out var plugin ) && ( plugin is T pluginAsT ) )
+    {
+      value = pluginAsT;
+      return true;
+    }
+
+    return false;
+  }
+
+  #endregion
+
+  #region Properties, Indexers
+
+  /// <summary>
+  /// The chart legend displays data about the datasets that are appearing on the chart.
+  /// </summary>
+  public ChartPluginsLegend Legend { get; set; } = new();
+
+  /// <summary>
+  /// The chart title defines text to draw at the top of the chart.
+  /// <see href="https://www.chartjs.org/docs/latest/configuration/title.html"/> 
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartPluginsTitle? Title { get; set; } = new();
+
+  /// <summary>
+  /// Tooltip for the element.
+  /// <see href="https://www.chartjs.org/docs/latest/configuration/tooltip.html"/>
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartPluginsTooltip? Tooltip { get; set; }
+
+  #endregion
 }
 
-public class ChartPluginsLegend
+public class ChartPluginsLegend : ChartPlugin
 {
-    #region Properties, Indexers
+  #region Properties, Indexers
 
-    /// <summary>
-    /// Alignment of the legend. Default values is 'center'. Other possible values 'start' and 'end'.
-    /// </summary>
-    public string? Align { get; set; } = "center";
+  /// <summary>
+  /// Alignment of the legend. Default values is 'center'. Other possible values 'start' and 'end'.
+  /// </summary>
+  public string? Align { get; set; } = "center";
 
-    /// <summary>
-    /// Is the legend shown? Default value is 'true'.
-    /// </summary>
-    public bool Display { get; set; } = true;
+  /// <summary>
+  /// Is the legend shown? Default value is 'true'.
+  /// </summary>
+  public bool Display { get; set; } = true;
 
-    /// <summary>
-    /// If <see langword="true" />, Marks that this box should take the full width/height of the canvas (moving other boxes). This is unlikely to need to be changed in day-to-day use.
-    /// </summary>
-    public bool FullSize { get; set; } = true;
+  /// <summary>
+  /// If <see langword="true" />, Marks that this box should take the full width/height of the canvas (moving other boxes). This is unlikely to need to be changed in day-to-day use.
+  /// </summary>
+  public bool FullSize { get; set; } = true;
 
-    /// <summary>
-    /// Label settings for the legend.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartPluginsLegendLabels? Labels { get; set; }
+  /// <summary>
+  /// Label settings for the legend.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartPluginsLegendLabels? Labels { get; set; }
 
-    /// <summary>
-    /// Maximum height of the legend, in pixels.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? MaxHeight { get; set; }
+  /// <summary>
+  /// Maximum height of the legend, in pixels.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? MaxHeight { get; set; }
 
-    /// <summary>
-    /// Maximum width of the legend, in pixels.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? MaxWidth { get; set; }
+  /// <summary>
+  /// Maximum width of the legend, in pixels.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? MaxWidth { get; set; }
 
-    /// <summary>
-    /// Position of the legend. Default value is 'top'. Other possible value is 'bottom'.
-    /// </summary>
-    public string Position { get; set; } = "top";
+  /// <summary>
+  /// Position of the legend. Default value is 'top'. Other possible value is 'bottom'.
+  /// </summary>
+  public string Position { get; set; } = "top";
 
-    /// <summary>
-    /// If <see langword="true" />, the Legend will show datasets in reverse order.
-    /// </summary>
-    public bool Reverse { get; set; } = false;
+  /// <summary>
+  /// If <see langword="true" />, the Legend will show datasets in reverse order.
+  /// </summary>
+  public bool Reverse { get; set; } = false;
 
-    /// <summary>
-    /// If <see langword="true" />, for rendering of the legends will go from right to left.
-    /// </summary>
-    public bool Rtl { get; set; } = false;
+  /// <summary>
+  /// If <see langword="true" />, for rendering of the legends will go from right to left.
+  /// </summary>
+  public bool Rtl { get; set; } = false;
 
-    /// <summary>
-    /// This will force the text direction 'rtl' or 'ltr' on the canvas for rendering the legend, regardless of the css specified on the canvas
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? TextDirection { get; set; }
-    
-    /// <summary>
-    /// Title object
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartPluginsLegendTitle? Title { get; set; }
+  /// <summary>
+  /// This will force the text direction 'rtl' or 'ltr' on the canvas for rendering the legend, regardless of the css specified on the canvas
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? TextDirection { get; set; }
 
-    #endregion
+  /// <summary>
+  /// Title object
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartPluginsLegendTitle? Title { get; set; }
+
+  #endregion
 }
 
-public class ChartPluginsLegendTitle
+public class ChartPluginsLegendTitle : ChartPlugin
 {
-    /// <summary>
-    /// Color of the legend. Default value is 'black'.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Color { get; set; }
+  /// <summary>
+  /// Color of the legend. Default value is 'black'.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Color { get; set; }
 
-    /// <summary>
-    /// Is the legend title displayed.
-    /// </summary>
-    public bool Display { get; set; } = true;
+  /// <summary>
+  /// Is the legend title displayed.
+  /// </summary>
+  public bool Display { get; set; } = true;
 
-    /// <summary>
-    /// Padding around the title.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? Padding { get; set; }
-    
-    /// <summary>
-    /// The string title
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Text { get; set; }
+  /// <summary>
+  /// Padding around the title.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? Padding { get; set; }
+
+  /// <summary>
+  /// The string title
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Text { get; set; }
 }
 
 /// <summary>
 /// The chart label settings
 /// <see href="https://www.chartjs.org/docs/latest/configuration/legend.html#legend-label-configuration" />
 /// </summary>
-public class ChartPluginsLegendLabels
+public class ChartPluginsLegendLabels : ChartPlugin
 {
-    /// <summary>
-    /// Width of coloured box.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? BoxWidth { get; set; }
+  /// <summary>
+  /// Width of coloured box.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? BoxWidth { get; set; }
 
-    /// <summary>
-    /// Height of the coloured box
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? BoxHeight { get; set; }
+  /// <summary>
+  /// Height of the coloured box
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? BoxHeight { get; set; }
 
-    /// <summary>
-    /// Override the borderRadius to use.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? BorderRadius { get; set; }
-    
-    /// <summary>
-    /// Color of label and the strikethrough.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Color { get; set; }
-    
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartFont? Font { get; set; }
-    
-    /// <summary>
-    /// Padding between rows of colored boxes.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? Padding { get; set; }
+  /// <summary>
+  /// Override the borderRadius to use.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? BorderRadius { get; set; }
 
-    /// <summary>
-    /// If specified, this style of point is used for the legend. Only used if <see cref="UsePointStyle"/>> is true.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? PointStyle { get; set; }
+  /// <summary>
+  /// Color of label and the strikethrough.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Color { get; set; }
 
-    /// <summary>
-    /// If <see cref="UsePointStyle"/> is <see langword="true" />, the width of the point style used for the legend.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? PointStyleWidth { get; set; }
-    
-    /// <summary>
-    /// Label borderRadius will match corresponding <see cref="BorderRadius"/>.
-    /// </summary>
-    public bool UseBorderRadius { get; set; } = false;
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartFont? Font { get; set; }
 
-    /// <summary>
-    /// If <see langword="true"/>, Label style will match corresponding point style (size is based on pointStyleWidth or the minimum value between <see cref="BoxWidth"/> and <see cref="Font"/> -> Size).
-    /// </summary>
-    public bool UsePointStyle { get; set; } = false;
+  /// <summary>
+  /// Padding between rows of colored boxes.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? Padding { get; set; }
+
+  /// <summary>
+  /// If specified, this style of point is used for the legend. Only used if <see cref="UsePointStyle"/>> is true.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? PointStyle { get; set; }
+
+  /// <summary>
+  /// If <see cref="UsePointStyle"/> is <see langword="true" />, the width of the point style used for the legend.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public int? PointStyleWidth { get; set; }
+
+  /// <summary>
+  /// Label borderRadius will match corresponding <see cref="BorderRadius"/>.
+  /// </summary>
+  public bool UseBorderRadius { get; set; } = false;
+
+  /// <summary>
+  /// If <see langword="true"/>, Label style will match corresponding point style (size is based on pointStyleWidth or the minimum value between <see cref="BoxWidth"/> and <see cref="Font"/> -> Size).
+  /// </summary>
+  public bool UsePointStyle { get; set; } = false;
 
 }
 
@@ -188,186 +246,186 @@ public class ChartPluginsLegendLabels
 /// The chart title defines text to draw at the top of the chart.
 /// <see href="https://www.chartjs.org/docs/latest/configuration/title.html" />
 /// </summary>
-public class ChartPluginsTitle
+public class ChartPluginsTitle : ChartPlugin
 {
-    #region Properties, Indexers
+  #region Properties, Indexers
 
-    /// <summary>
-    /// Alignment of the title.
-    /// Options are: 'start', 'center', and 'end'
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Align { get; set; } = "center";
-    /// <summary>
-    /// Color of text.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Color { get; set; } = "black";
+  /// <summary>
+  /// Alignment of the title.
+  /// Options are: 'start', 'center', and 'end'
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Align { get; set; } = "center";
+  /// <summary>
+  /// Color of text.
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Color { get; set; } = "black";
 
-    /// <summary>
-    /// Is the title shown?
-    /// </summary>
-    public bool Display { get; set; }
+  /// <summary>
+  /// Is the title shown?
+  /// </summary>
+  public bool Display { get; set; }
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartFont? Font { get; set; }
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartFont? Font { get; set; }
 
-    //fullSize
-    //padding
-    //position
+  //fullSize
+  //padding
+  //position
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Text { get; set; }
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Text { get; set; }
 
-    #endregion
+  #endregion
 }
 
 /// <summary>
 /// Tooltip for bubble, doughnut, pie, polar area, and scatter charts
 /// <see href="https://www.chartjs.org/docs/latest/configuration/tooltip.html" />
 /// </summary>
-public class ChartPluginsTooltip
+public class ChartPluginsTooltip : ChartPlugin
 {
-    #region Properties, Indexers
+  #region Properties, Indexers
 
-    /// <summary>
-    /// Background color of the tooltip.
-    /// </summary>
-    public string BackgroundColor { get; set; } = "rgba(0, 0, 0, 0.8)";
+  /// <summary>
+  /// Background color of the tooltip.
+  /// </summary>
+  public string BackgroundColor { get; set; } = "rgba(0, 0, 0, 0.8)";
 
-    /// <summary>
-    /// Horizontal alignment of the body text lines. left/right/center.
-    /// </summary>
-    public string BodyAlign { get; set; } = "left";
+  /// <summary>
+  /// Horizontal alignment of the body text lines. left/right/center.
+  /// </summary>
+  public string BodyAlign { get; set; } = "left";
 
-    /// <summary>
-    /// Color of body text.
-    /// </summary>
-    public string BodyColor { get; set; } = "#fff";
+  /// <summary>
+  /// Color of body text.
+  /// </summary>
+  public string BodyColor { get; set; } = "#fff";
 
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public ChartPluginsTooltipFont? BodyFont { get; set; }
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public ChartPluginsTooltipFont? BodyFont { get; set; }
 
-    /// <summary>
-    /// Spacing to add to top and bottom of each tooltip item.
-    /// </summary>
-    public int BodySpacing { get; set; } = 2;
+  /// <summary>
+  /// Spacing to add to top and bottom of each tooltip item.
+  /// </summary>
+  public int BodySpacing { get; set; } = 2;
 
-    /// <summary>
-    /// Extra distance to move the end of the tooltip arrow away from the tooltip point.
-    /// </summary>
-    public int CaretPadding { get; set; } = 2;
+  /// <summary>
+  /// Extra distance to move the end of the tooltip arrow away from the tooltip point.
+  /// </summary>
+  public int CaretPadding { get; set; } = 2;
 
-    /// <summary>
-    /// Size, in px, of the tooltip arrow.
-    /// </summary>
-    public int CaretSize { get; set; } = 5;
+  /// <summary>
+  /// Size, in px, of the tooltip arrow.
+  /// </summary>
+  public int CaretSize { get; set; } = 5;
 
-    /// <summary>
-    /// If <see langword="true" />, color boxes are shown in the tooltip.
-    /// </summary>
-    public bool DisplayColors { get; set; } = true;
+  /// <summary>
+  /// If <see langword="true" />, color boxes are shown in the tooltip.
+  /// </summary>
+  public bool DisplayColors { get; set; } = true;
 
-    /// <summary>
-    /// Are on-canvas tooltips enabled?
-    /// </summary>
-    public bool Enabled { get; set; } = true;
+  /// <summary>
+  /// Are on-canvas tooltips enabled?
+  /// </summary>
+  public bool Enabled { get; set; } = true;
 
-    /// <summary>
-    /// Horizontal alignment of the footer text lines. left/right/center.
-    /// </summary>
-    public string FooterAlign { get; set; } = "left";
+  /// <summary>
+  /// Horizontal alignment of the footer text lines. left/right/center.
+  /// </summary>
+  public string FooterAlign { get; set; } = "left";
 
-    /// <summary>
-    /// Color of footer text.
-    /// </summary>
-    public string FooterColor { get; set; } = "#fff";
+  /// <summary>
+  /// Color of footer text.
+  /// </summary>
+  public string FooterColor { get; set; } = "#fff";
 
-    public ChartPluginsTooltipFont FooterFont { get; set; } = new();
+  public ChartPluginsTooltipFont FooterFont { get; set; } = new();
 
-    /// <summary>
-    /// Margin to add before drawing the footer.
-    /// </summary>
-    public int FooterMarginTop { get; set; } = 6;
+  /// <summary>
+  /// Margin to add before drawing the footer.
+  /// </summary>
+  public int FooterMarginTop { get; set; } = 6;
 
-    /// <summary>
-    /// Spacing to add to top and bottom of each footer line.
-    /// </summary>
-    public int FooterSpacing { get; set; } = 2;
+  /// <summary>
+  /// Spacing to add to top and bottom of each footer line.
+  /// </summary>
+  public int FooterSpacing { get; set; } = 2;
 
-    /// <summary>
-    /// Horizontal alignment of the title text lines. left/right/center.
-    /// </summary>
-    public string TitleAlign { get; set; } = "left";
+  /// <summary>
+  /// Horizontal alignment of the title text lines. left/right/center.
+  /// </summary>
+  public string TitleAlign { get; set; } = "left";
 
-    /// <summary>
-    /// Color of title text.
-    /// </summary>
-    public string TitleColor { get; set; } = "#fff";
+  /// <summary>
+  /// Color of title text.
+  /// </summary>
+  public string TitleColor { get; set; } = "#fff";
 
-    public ChartPluginsTooltipFont TitleFont { get; set; } = new();
+  public ChartPluginsTooltipFont TitleFont { get; set; } = new();
 
-    /// <summary>
-    /// Margin to add on bottom of title section.
-    /// </summary>
-    public int TitleMarginBottom { get; set; } = 6;
+  /// <summary>
+  /// Margin to add on bottom of title section.
+  /// </summary>
+  public int TitleMarginBottom { get; set; } = 6;
 
-    /// <summary>
-    /// Spacing to add to top and bottom of each title line.
-    /// </summary>
-    public int TitleSpacing { get; set; } = 2;
+  /// <summary>
+  /// Spacing to add to top and bottom of each title line.
+  /// </summary>
+  public int TitleSpacing { get; set; } = 2;
 
-    /// <summary>
-    /// Position of the tooltip caret in the X direction. left/center/right.
-    /// </summary>
-    public string? XAlign { get; set; }
+  /// <summary>
+  /// Position of the tooltip caret in the X direction. left/center/right.
+  /// </summary>
+  public string? XAlign { get; set; }
 
-    /// <summary>
-    /// Position of the tooltip caret in the Y direction. top/center/bottom.
-    /// </summary>
-    public string? YAlign { get; set; }
+  /// <summary>
+  /// Position of the tooltip caret in the Y direction. top/center/bottom.
+  /// </summary>
+  public string? YAlign { get; set; }
 
-    #endregion
+  #endregion
 }
 
 /// <summary>
 ///     <see href="https://www.chartjs.org/docs/latest/general/fonts.html" />
 /// </summary>
-public class ChartPluginsTooltipFont
+public class ChartPluginsTooltipFont : ChartPlugin
 {
-    #region Properties, Indexers
+  #region Properties, Indexers
 
-    /// <summary>
-    /// Default font family for all text, follows CSS font-family options.
-    /// 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Family { get; set; }
+  /// <summary>
+  /// Default font family for all text, follows CSS font-family options.
+  /// 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Family { get; set; }
 
-    /// <summary>
-    /// Height of an individual line of text
-    /// <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/line-height" />
-    /// </summary>
-    public double LineHeight { get; set; } = 1.2;
+  /// <summary>
+  /// Height of an individual line of text
+  /// <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/line-height" />
+  /// </summary>
+  public double LineHeight { get; set; } = 1.2;
 
-    /// <summary>
-    /// Default font size (in px) for text. Does not apply to radialLinear scale point labels.
-    /// </summary>
-    public int Size { get; set; } = 12;
+  /// <summary>
+  /// Default font size (in px) for text. Does not apply to radialLinear scale point labels.
+  /// </summary>
+  public int Size { get; set; } = 12;
 
-    /// <summary>
-    /// Default font style. Does not apply to tooltip title or footer. Does not apply to chart title.
-    /// Follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Style { get; set; }
+  /// <summary>
+  /// Default font style. Does not apply to tooltip title or footer. Does not apply to chart title.
+  /// Follows CSS font-style options (i.e. normal, italic, oblique, initial, inherit).
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Style { get; set; }
 
-    /// <summary>
-    /// Default font weight (boldness).
-    /// <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight" />
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Weight { get; set; } = "bold";
+  /// <summary>
+  /// Default font weight (boldness).
+  /// <see href="https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight" />
+  /// </summary>
+  [JsonIgnore( Condition = JsonIgnoreCondition.WhenWritingNull )]
+  public string? Weight { get; set; } = "bold";
 
-    #endregion
+  #endregion
 }


### PR DESCRIPTION
Hi @gvreddy04 
Here's another pull request that adds built-in support for two common chart.js plugins: annotations and zoom.
In addition it allows the user to load any additional plugins without modifying the library, the documentation shows an example for the dragdata plugin.

Note that the documentation for this pull request and my previous one (time scales) requires external libraries to be loaded for the demo to work.