### PR TITLE
Set selected items in grid view when using the grid to edit data

### DIFF
--- a/blazorbootstrap/Components/Grid/Grid.razor.cs
+++ b/blazorbootstrap/Components/Grid/Grid.razor.cs
@@ -53,7 +53,7 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
         {
             await RefreshDataAsync(firstRender);
             isFirstRenderComplete = true;
-        } 
+        }
 
         await base.OnAfterRenderAsync(firstRender);
     }

--- a/blazorbootstrap/Components/Grid/Grid.razor.cs
+++ b/blazorbootstrap/Components/Grid/Grid.razor.cs
@@ -53,7 +53,7 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
         {
             await RefreshDataAsync(firstRender);
             isFirstRenderComplete = true;
-        }
+        } 
 
         await base.OnAfterRenderAsync(firstRender);
     }
@@ -383,6 +383,7 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
         allItemsSelected = bool.TryParse(args?.Value?.ToString(), out var checkboxState) && checkboxState;
         selectedItems = allItemsSelected ? new HashSet<TItem>(items!) : new HashSet<TItem>();
         SelectedItemsCount = selectedItems.Count;
+        SetSelected = selectedItems;
         await CheckOrUnCheckAll();
 
         if (SelectedItemsChanged.HasDelegate)
@@ -456,8 +457,8 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
     private async Task RefreshSelectionAsync()
     {
         selectedItems = (items?.Count ?? 0) == 0
-                            ? new HashSet<TItem>()
-                            : selectedItems?.Intersect(items!).ToHashSet() ?? new HashSet<TItem>();
+            ? new HashSet<TItem>()
+            : selectedItems?.Intersect(items!).ToHashSet() ?? new HashSet<TItem>();
 
         SelectedItemsCount = selectedItems.Count;
         allItemsSelected = SelectedItemsCount > 0 && items!.Count == SelectedItemsCount;
@@ -583,6 +584,19 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
     /// </remarks>
     [Parameter]
     public bool AllowRowClick { get; set; }
+
+    /// <summary>
+    /// Gets or sets the grid set selection.
+    /// </summary>
+    /// <remarks>
+    /// Default value is false.
+    /// </remarks>
+    [Parameter]
+    public HashSet<TItem> SetSelected
+    {
+        get => selectedItems;
+        set => selectedItems = value;
+    }
 
     /// <summary>
     /// Gets or sets the grid selection.

--- a/blazorbootstrap/Components/Grid/Grid.razor.cs
+++ b/blazorbootstrap/Components/Grid/Grid.razor.cs
@@ -186,10 +186,8 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
 
         if (AllowSelection)
         {
-            PrepareCheckboxIds();
-
-            if (!firstRender)
-                await RefreshSelectionAsync();
+            PrepareCheckboxIds(); 
+            await RefreshSelectionAsync();
         }
 
         requestInProgress = false;


### PR DESCRIPTION
Setup the grid using SetSelected

     <Grid @ref="levelGrid" TItem="Level"
       Class="table table-hover table-bordered marginBottom1"
       Data="_levels"
       AllowFiltering="true"
       AllowSelection="true"
       FixedHeader="true"
       Height="300"
       Unit="Unit.Px"
       SelectionMode="GridSelectionMode.Multiple"
       SelectedItemsChanged="OnSelectedItemsChanged"
       SetSelected="setSelected"
       Responsive="true">

     <GridColumns>
         <GridColumn TItem="Level" HeaderText="Additional Levels" PropertyName="Description">
             @context.Description
         </GridColumn>
     </GridColumns>
     </Grid>

Code:

     HashSet<Level> setSelected = [];

     protected override async Task<Task> OnParametersSetAsync()
     {
          Input = new InputModel
          {
               Description = _course.Description,
               Selectedlevels = _course.AdditionalLevels.Select(x => x.Level).ToHashSet()
          };
          setSelected = _course.AdditionalLevels.Select(x => x.Level).ToHashSet();
         return base.OnParametersSetAsync();
     }
      private Task OnSelectedItemsChanged(HashSet<Level> levels)
      {
           Input.Selectedlevels = levels;
           setSelected = Input.Selectedlevels;
           return Task.CompletedTask;
      }
     private sealed class InputModel
     {
         [Required]
         [Display(Name = "Description")]
         public string Description { get; set; }

         [Required]
         [MinLength(1)]
         public HashSet<Level> Selectedlevels { get; set; }
     }

