### PR TITLE
Add constructor with ToastType only

### DIFF
--- a/blazorbootstrap/Models/ToastMessage.cs
+++ b/blazorbootstrap/Models/ToastMessage.cs
@@ -9,67 +9,47 @@ public class ToastMessage : IEquatable<ToastMessage>
         Id = Guid.NewGuid();
     }
 
-    public ToastMessage(ToastType type, string message)
+    public ToastMessage(ToastType type)
+        : this()
     {
-        Id = Guid.NewGuid();
         Type = type;
+    }
+
+    public ToastMessage(ToastType type, string message)
+        : this(type)
+    {
         Message = message;
     }
 
     public ToastMessage(ToastType type, string title, string message)
+        : this(type, message)
     {
-        Id = Guid.NewGuid();
-        Type = type;
         Title = title;
-        Message = message;
     }
 
     public ToastMessage(ToastType type, IconName iconName, string title, string message)
+        : this(type, title, message)
     {
-        Id = Guid.NewGuid();
-        Type = type;
         IconName = iconName;
-        Title = title;
-        Message = message;
     }
 
     public ToastMessage(ToastType type, string customIconName, string title, string message)
+        : this(type, title, message)
     {
-        Id = Guid.NewGuid();
-        Type = type;
         CustomIconName = customIconName;
-        Title = title;
-        Message = message;
     }
 
-    public ToastMessage(ToastType type, IconName iconName, string title, string helpText, string message)
+    public ToastMessage(ToastType type, IconName iconName, string title, string helpText, string message, bool autoHide = false)
+        : this(type, iconName, title, message)
     {
-        Id = Guid.NewGuid();
-        Type = type;
-        IconName = iconName;
-        Title = title;
         HelpText = helpText;
-        Message = message;
+        AutoHide = autoHide;
     }
 
-    public ToastMessage(ToastType type, string customIconName, string title, string helpText, string message)
+    public ToastMessage(ToastType type, string customIconName, string title, string helpText, string message, bool autoHide = false)
+        : this(type, customIconName, title, message)
     {
-        Id = Guid.NewGuid();
-        Type = type;
-        CustomIconName = customIconName;
-        Title = title;
         HelpText = helpText;
-        Message = message;
-    }
-
-    public ToastMessage(ToastType type, string customIconName, string title, string helpText, string message, bool autoHide)
-    {
-        Id = Guid.NewGuid();
-        Type = type;
-        CustomIconName = customIconName;
-        Title = title;
-        HelpText = helpText;
-        Message = message;
         AutoHide = autoHide;
     }
 


### PR DESCRIPTION
Add a constructor for `ToastMessage` that takes `ToastType` only.

With the new `RenderFragment` toast content a constructor that takes `ToastType` but not a string message now makes sense.

At the same time make some changes to other constructors:
o Invoke simpler constructors from more complex ones to avoid duplicating code
o Use default argument for `autoHide` instead of writing two separate constructors
o Add `autoHide` parameter to constructor that takes `IconName` to mirror the constructor that takes `customIconName`