### PR TITLE
Fix show and hide behavior for nested collapses

### DIFF
--- a/BlazorBootstrap.Demo.RCL/Components/Pages/Accordion/Accordion_Demo_01_Examples.razor
+++ b/BlazorBootstrap.Demo.RCL/Components/Pages/Accordion/Accordion_Demo_01_Examples.razor
@@ -2,6 +2,18 @@
     <AccordionItem Title="Accordion Item #1">
         <Content>
             <b>This is the first item's accordion body.</b> It is shown by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. It's also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.
+            <Accordion>
+                <AccordionItem Title="Accordion Item #1.1">
+                    <Content>
+                        <b>This is the first item in a nested accordion body.</b>.
+                    </Content>
+                </AccordionItem>
+                <AccordionItem Title="Accordion Item #1.2">
+                    <Content>
+                        <b>This is the second item in a nested accordion body.</b>.
+                    </Content>
+                </AccordionItem>
+            </Accordion>
         </Content>
     </AccordionItem>
     <AccordionItem Title="Accordion Item #2">

--- a/blazorbootstrap/Components/Accordion/AccordionItem.razor.cs
+++ b/blazorbootstrap/Components/Accordion/AccordionItem.razor.cs
@@ -27,30 +27,34 @@ public partial class AccordionItem : BlazorBootstrapComponentBase
 
     internal async Task ShowAsync() => await collapse.ShowAsync();
 
-    private async Task OnCollapseHiddenAsync()
+    private async Task OnCollapseHiddenAsync(string collapseId)
     {
+        if (collapseId != collapse.Id) return;
         if (Parent is not null && Parent.OnHidden.HasDelegate)
             await Parent.OnHidden.InvokeAsync(new AccordionEventArgs(Name, Title));
     }
 
-    private async Task OnCollapseHidingAsync()
+    private async Task OnCollapseHidingAsync(string collapseId)
     {
+        if (collapseId != collapse.Id) return;
         isCollapsed = true;
 
         if (Parent is not null && Parent.OnHiding.HasDelegate)
             await Parent.OnHiding.InvokeAsync(new AccordionEventArgs(Name, Title));
     }
 
-    private async Task OnCollapseShowingAsync()
+    private async Task OnCollapseShowingAsync(string collapseId)
     {
+        if (collapseId != collapse.Id) return;
         isCollapsed = false;
 
         if (Parent is not null && Parent.OnShowing.HasDelegate)
             await Parent.OnShowing.InvokeAsync(new AccordionEventArgs(Name, Title));
     }
 
-    private async Task OnCollapseShownAsync()
+    private async Task OnCollapseShownAsync(string collapseId)
     {
+        if (collapseId != collapse.Id) return;
         if (Parent is not null && Parent.OnShown.HasDelegate)
             await Parent.OnShown.InvokeAsync(new AccordionEventArgs(Name, Title));
     }

--- a/blazorbootstrap/Components/Collapse/Collapse.razor.cs
+++ b/blazorbootstrap/Components/Collapse/Collapse.razor.cs
@@ -47,16 +47,16 @@ public partial class Collapse : BlazorBootstrapComponentBase
     }
 
     [JSInvokable]
-    public async Task bsHiddenCollapse() => await OnHidden.InvokeAsync();
+    public async Task bsHiddenCollapse(string collapseId) => await OnHidden.InvokeAsync(collapseId);
 
     [JSInvokable]
-    public async Task bsHideCollapse() => await OnHiding.InvokeAsync();
+    public async Task bsHideCollapse(string collapseId) => await OnHiding.InvokeAsync(collapseId);
 
     [JSInvokable]
-    public async Task bsShowCollapse() => await OnShowing.InvokeAsync();
+    public async Task bsShowCollapse(string collapseId) => await OnShowing.InvokeAsync(collapseId);
 
     [JSInvokable]
-    public async Task bsShownCollapse() => await OnShown.InvokeAsync();
+    public async Task bsShownCollapse(string collapseId) => await OnShown.InvokeAsync(collapseId);
 
     /// <summary>
     /// Hides a collapsible element.
@@ -105,26 +105,26 @@ public partial class Collapse : BlazorBootstrapComponentBase
     /// This event is fired when a collapse element has been hidden from the user (will wait for CSS transitions to complete).
     /// </summary>
     [Parameter]
-    public EventCallback OnHidden { get; set; }
+    public EventCallback<string> OnHidden { get; set; }
 
     /// <summary>
     /// This event is fired immediately when the hide method has been called.
     /// </summary>
     [Parameter]
-    public EventCallback OnHiding { get; set; }
+    public EventCallback<string> OnHiding { get; set; }
 
     /// <summary>
     /// This event fires immediately when the show instance method is called.
     /// </summary>
     [Parameter]
-    public EventCallback OnShowing { get; set; }
+    public EventCallback<string> OnShowing { get; set; }
 
     /// <summary>
     /// This event is fired when a collapse element has been made visible to the user (will wait for CSS transitions to
     /// complete).
     /// </summary>
     [Parameter]
-    public EventCallback OnShown { get; set; }
+    public EventCallback<string> OnShown { get; set; }
 
     /// <summary>
     /// Gets or sets the parent selector, DOM element.

--- a/blazorbootstrap/wwwroot/blazor.bootstrap.js
+++ b/blazorbootstrap/wwwroot/blazor.bootstrap.js
@@ -186,16 +186,16 @@ window.blazorBootstrap = {
                 return;
 
             collapseEl.addEventListener('show.bs.collapse', (event) => {
-                dotNetHelper.invokeMethodAsync('bsShowCollapse');
+                dotNetHelper.invokeMethodAsync('bsShowCollapse', event.target?.id);
             });
             collapseEl.addEventListener('shown.bs.collapse', (event) => {
-                dotNetHelper.invokeMethodAsync('bsShownCollapse');
+                dotNetHelper.invokeMethodAsync('bsShownCollapse', event.target?.id);
             });
             collapseEl.addEventListener('hide.bs.collapse', (event) => {
-                dotNetHelper.invokeMethodAsync('bsHideCollapse');
+                dotNetHelper.invokeMethodAsync('bsHideCollapse', event.target?.id);
             });
             collapseEl.addEventListener('hidden.bs.collapse', (event) => {
-                dotNetHelper.invokeMethodAsync('bsHiddenCollapse');
+                dotNetHelper.invokeMethodAsync('bsHiddenCollapse', event.target?.id);
             });
 
             let options = { parent: parent, toggle: toggle };


### PR DESCRIPTION
This PR fixes the show and hide behaviors for nested collapses, for example in nested accordion, click on the AccordionItem should not affect both the child and the parent at the same time.

The accordion first example is updated to contain a nested case.

