### PR TITLE
Enhance SortableList<TItem> docs and parameter metadata

### DIFF
--- a/BlazorBootstrap.Demo.RCL/Components/Pages/Docs/SortableList/SortableList_Doc_01_Documentation.razor
+++ b/BlazorBootstrap.Demo.RCL/Components/Pages/Docs/SortableList/SortableList_Doc_01_Documentation.razor
@@ -15,19 +15,21 @@
 </Section>
 
 <Section Class="p-0" Size="HeadingSize.H3" Name="Parameters" PageUrl="@pageUrl" Link="parameters">
-    <DocxTable TItem="SortableList<object>" DocType="DocType.Parameters" />
+    <DocxTable TItem="SortableList<TItem>" DocType="DocType.Parameters" />
 </Section>
 
 <Section Class="p-0" Size="HeadingSize.H3" Name="Events" PageUrl="@pageUrl" Link="events">
-    <DocxTable TItem="SortableList<object>" DocType="DocType.Events" />
+    <DocxTable TItem="SortableList<TItem>" DocType="DocType.Events" />
 </Section>
 
 @code {
-    private const string componentName = nameof(SortableList<object>);
+    private const string componentName = nameof(SortableList<TItem>);
     private const string pageUrl = DemoRouteConstants.Docs_URL_SortableList;
     private const string pageTitle = componentName;
     private const string pageDescription = $"This documentation provides a comprehensive reference for the <code>{componentName}</code> component, guiding you through its configuration options.";
     private const string metaTitle = $"Blazor {componentName} Component";
     private const string metaDescription = $"This documentation provides a comprehensive reference for the {componentName} component, guiding you through its configuration options.";
     private const string imageUrl = DemoScreenshotSrcConstants.Demos_URL_SortableList;
+
+    public class TItem : object { }
 }

--- a/blazorbootstrap/Components/SortableList/SortableList.razor.cs
+++ b/blazorbootstrap/Components/SortableList/SortableList.razor.cs
@@ -80,151 +80,205 @@ public partial class SortableList<TItem> : BlazorBootstrapComponentBase
 
     /// <summary>
     /// Gets or sets a value indicating whether sorting is allowed for the list.
+    /// <para>
+    /// Default value is <see langword="true"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is true.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(true)]
+    [Description("Gets or sets a value indicating whether sorting is allowed for the list.")]
     [Parameter]
     public bool AllowSorting { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the content to be rendered within the component.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the content to be rendered within the component.")]
     [Parameter]
-    public RenderFragment ChildContent { get; set; } = default!;
+    public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
     /// Gets or sets the items.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the items.")]
     [Parameter]
-    public List<TItem> Data { get; set; } = default!;
+    public List<TItem>? Data { get; set; }
 
     /// <summary>
     /// Gets or sets the CSS class applied to disabled items.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the CSS class applied to disabled items.")]
     [Parameter]
-    public string? DisabledItemCssClass { get; set; } = default!;
+    public string? DisabledItemCssClass { get; set; }
 
     /// <summary>
     /// Gets or sets a delegate that determines whether an item should be disabled.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets a delegate that determines whether an item should be disabled.")]
     [Parameter]
-    public Func<TItem, bool> DisableItem { get; set; } = default!;
+    public Func<TItem, bool>? DisableItem { get; set; }
 
     /// <summary>
     /// Gets or sets the empty data template.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the empty data template.")]
     [Parameter]
-    public RenderFragment EmptyDataTemplate { get; set; } = default!;
+    public RenderFragment? EmptyDataTemplate { get; set; }
 
     /// <summary>
     /// Gets or sets the text to display when there are no records in the list.
-    /// </summary>
-    /// <remarks>
+    /// <para>
     /// Default value is `No records to display`.
-    /// </remarks>
+    /// </para>
+    /// </summary>
+    [AddedVersion("2.2.0")]
+    [DefaultValue("No records to display")]
+    [Description("Gets or sets the text to display when there are no records in the list.")]
     [Parameter]
     public string EmptyText { get; set; } = "No records to display";
 
     /// <summary>
     /// Gets or sets the group name associated with the list.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the group name associated with the list.")]
     [Parameter]
     public string? Group { get; set; }
 
     /// <summary>
     /// Gets or sets the CSS selector for the drag handle element.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the CSS selector for the drag handle element.")]
     [Parameter]
     public string? Handle { get; set; }
 
     /// <summary>
     /// Gets or sets the loading state.
+    /// <para>
+    /// Default value is <see langword="false"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is false.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(false)]
+    [Description("Gets or sets the loading state.")]
     [Parameter]
     public bool IsLoading { get; set; }
 
     /// <summary>
     /// Gets or sets the template used to render individual items in the list.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the template used to render individual items in the list.")]
     [Parameter]
     public RenderFragment<TItem>? ItemTemplate { get; set; }
 
     /// <summary>
     /// Gets or sets the loading template.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the loading template.")]
     [Parameter]
     public RenderFragment LoadingTemplate { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the name of the <see cref="SortableList{TItem}" /> component.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the name of the <b>SortableList{TItem}</b> component.")]
     [Parameter]
     public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets an event callback that fires when an item is added to the list.
     /// </summary>
+    [AddedVersion("2.2.0")]
+    [Description("Gets or sets an event callback that fires when an item is added to the list.")]
     [Parameter]
     public EventCallback<SortableListEventArgs> OnAdd { get; set; }
 
     /// <summary>
     /// Gets or sets an event callback that fires when an item is removed from the list.
     /// </summary>
+    [AddedVersion("2.2.0")]
+    [Description("Gets or sets an event callback that fires when an item is removed from the list.")]
     [Parameter]
     public EventCallback<SortableListEventArgs> OnRemove { get; set; }
 
     /// <summary>
     /// Gets or sets an event callback that fires when an item is updated in the list.
     /// </summary>
+    [AddedVersion("2.2.0")]
+    [Description("Gets or sets an event callback that fires when an item is updated in the list.")]
     [Parameter]
     public EventCallback<SortableListEventArgs> OnUpdate { get; set; }
 
     /// <summary>
     /// Gets or sets the pull mode for the sortable list.
-    /// </summary>
-    /// <remarks>
+    /// <para>
     /// Default value is <see cref="SortableListPullMode.True" />.
-    /// </remarks>
+    /// </para>
+    /// </summary>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(SortableListPullMode.True)]
+    [Description("Gets or sets the pull mode for the sortable list.")]
     [Parameter]
     public SortableListPullMode Pull { get; set; } = SortableListPullMode.True;
 
     /// <summary>
     /// Gets or sets the put mode for the sortable list.
-    /// </summary>
-    /// <remarks>
+    /// <para>
     /// Default value is <see cref="SortableListPutMode.True" />.
-    /// </remarks>
+    /// </para>
+    /// </summary>
+    [AddedVersion("2.2.0")]
+    [DefaultValue(SortableListPutMode.True)]
+    [Description("Gets or sets the put mode for the sortable list.")]
     [Parameter]
     public SortableListPutMode Put { get; set; } = SortableListPutMode.True;
 


### PR DESCRIPTION
- Update documentation to use TItem instead of object for accuracy.
- Add dummy TItem class for documentation purposes.
- Improve XML docs for all public parameters, using <para> for defaults.
- Add [AddedVersion], [DefaultValue], and [Description] attributes to parameters.
- Make ChildContent, Data, DisabledItemCssClass, DisableItem, and EmptyDataTemplate nullable.
- Standardize and clarify parameter documentation for better tooling and code analysis support.