### PR TITLE
Update Image props docs and add metadata attributes

### DIFF
--- a/blazorbootstrap/Components/Image/Image.razor.cs
+++ b/blazorbootstrap/Components/Image/Image.razor.cs
@@ -11,37 +11,49 @@ public partial class Image: BlazorBootstrapComponentBase
 
     /// <summary>
     /// Gets or sets the alternate text for the image.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("3.0.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the alternate text for the image.")]
     [Parameter]
     public string? Alt { get; set; }
 
     /// <summary>
     /// Gets or sets the source of the image.
+    /// <para>
+    /// Default value is <see langword="null"/>.
+    /// </para>
     /// </summary>
-    /// <remarks>
-    /// Default value is null.
-    /// </remarks>
+    [AddedVersion("3.0.0")]
+    [DefaultValue(null)]
+    [Description("Gets or sets the source of the image.")]
     [Parameter]
     public string? Src { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the image is responsive.
-    /// </summary>
-    /// <remarks>
+    /// <para>
     /// Default value is <see langword="true"/>.
-    /// </remarks>
+    /// </para>
+    /// </summary>
+    [AddedVersion("3.0.0")]
+    [DefaultValue(true)]
+    [Description("Gets or sets a value indicating whether the image is responsive.")]
     [Parameter]
     public bool IsResponsive { get; set; } = true;
 
     /// <summary>
     /// Makes the image have a rounded 1px border appearance if set to <see langword="true"/>.
-    /// </summary>
-    /// <remarks>
+    /// <para>
     /// Default value is <see langword="false"/>.
-    /// </remarks>
+    /// </para>
+    /// </summary>
+    [AddedVersion("3.0.0")]
+    [DefaultValue(false)]
+    [Description("Makes the image have a rounded 1px border appearance if set to <b>true</b>.")]
     [Parameter]
     public  bool IsThumbnail { get; set; }
 


### PR DESCRIPTION
Updated XML docs for Alt, Src, IsResponsive, and IsThumbnail properties in the Image component to use <para> for default values. Added [AddedVersion], [DefaultValue], and [Description] attributes to each property. Clarified IsThumbnail description regarding border appearance.