### PR TITLE
Refine grab cursor for sortable list items and handles

### DIFF
--- a/blazorbootstrap/Components/SortableList/SortableList.razor.css
+++ b/blazorbootstrap/Components/SortableList/SortableList.razor.css
@@ -1,3 +1,0 @@
-﻿.list-group-item {
-    cursor: grab !important;
-}

--- a/blazorbootstrap/wwwroot/blazor.bootstrap.css
+++ b/blazorbootstrap/wwwroot/blazor.bootstrap.css
@@ -638,3 +638,12 @@ main {
     color: var(--bs-link-hover-color);
     text-decoration: underline;
 }
+
+/* sortable-list */
+.list-group-item:not(:has(.bb-sortable-list-handle)) {
+    cursor: grab !important;
+}
+
+.bb-sortable-list-handle .bi-grip-vertical::before {
+    cursor: grab !important;
+}


### PR DESCRIPTION
Updated CSS so the grab cursor appears only on sortable list items without handles, or specifically on the handle icon when present. This improves clarity and user experience when interacting with sortable lists.