### PR TITLE
Improve PDF password prompt cancellation handling

### DIFF
--- a/BlazorBootstrap.Demo.RCL/Components/Pages/Demos/PdfViewer/PdfViewer_Demo_05_Password_Protected_B_Prompt_For_Password.razor
+++ b/BlazorBootstrap.Demo.RCL/Components/Pages/Demos/PdfViewer/PdfViewer_Demo_05_Password_Protected_B_Prompt_For_Password.razor
@@ -1,6 +1,8 @@
 @if (showPdfViewer)
 {
-    <PdfViewer Class="mb-3" Url="@($"../{DemoStringConstants.StaticAssets_Docs_Path}/pdf_password_protected.pdf")" PromptForPassword="true" />
+    <PdfViewer Class="mb-3"
+               Url="@($"../{DemoStringConstants.StaticAssets_Docs_Path}/pdf_password_protected.pdf")"
+               OnDocumentLoadError="OnDocumentLoadError" />
 }
 else
 {
@@ -9,4 +11,6 @@ else
 
 @code {
     private bool showPdfViewer = false;
+
+    private void OnDocumentLoadError(string errorMessage) => showPdfViewer = false;
 }


### PR DESCRIPTION
Added OnDocumentLoadError callback in Blazor to hide the PDF viewer on load errors. Updated JS to detect password prompt cancellation, destroy loading task, and notify Blazor, preventing repeated prompts and improving user experience.