### PR TITLE
Add auto-focus option for Yes button in ConfirmDialog

### DIFF
--- a/blazorbootstrap/Components/ConfirmDialog/ConfirmDialog.razor.cs
+++ b/blazorbootstrap/Components/ConfirmDialog/ConfirmDialog.razor.cs
@@ -122,7 +122,7 @@ public partial class ConfirmDialog : BlazorBootstrapComponentBase
 
         StateHasChanged();
 
-        Task.Run(async () => await SafeInvokeVoidAsync("window.blazorBootstrap.confirmDialog.show", Id));
+        Task.Run(async () => await SafeInvokeVoidAsync("window.blazorBootstrap.confirmDialog.show", Id, shouldAutoFocusYesButton));
 
         return task;
     }


### PR DESCRIPTION
Updated ConfirmDialog to pass shouldAutoFocusYesButton to the JS show function, enabling automatic focus on the "Yes" button when the dialog appears.