### PR TITLE
Fix lineWidth typo and adjust ctx.restore() placement

### DIFF
--- a/blazorbootstrap/wwwroot/blazor.bootstrap.js
+++ b/blazorbootstrap/wwwroot/blazor.bootstrap.js
@@ -1423,18 +1423,17 @@ window.blazorChart.line = {
                         ctx.setLineDash([5, 5]);
                         ctx.moveTo(activePoint.element.x, chart.chartArea.top);
                         ctx.lineTo(activePoint.element.x, activePoint.element.y);
-                        ctx.linewidth = 2;
+                        ctx.lineWidth = 2;
                         ctx.strokeStyle = 'grey';
                         ctx.stroke();
-                        ctx.restore();
 
                         ctx.beginPath();
-                        ctx.setLineDash([5, 5]);
                         ctx.moveTo(activePoint.element.x, activePoint.element.y);
                         ctx.lineTo(activePoint.element.x, chart.chartArea.bottom);
-                        ctx.linewidth = 2;
+                        ctx.lineWidth = 2;
                         ctx.strokeStyle = 'grey';
                         ctx.stroke();
+
                         ctx.restore();
                     }
                 },


### PR DESCRIPTION
Corrected canvas context property from linewidth to lineWidth for proper line rendering. Moved ctx.restore() to after both drawing operations to ensure canvas state is restored correctly.