### PR TITLE
Add grid paginator position option

### DIFF
--- a/blazorbootstrap/Components/Grid/Grid.razor
+++ b/blazorbootstrap/Components/Grid/Grid.razor
@@ -8,6 +8,42 @@
 
 @if (columns.Any())
 {   
+    @if (PlacePaginationBeforeGrid && AllowPaging && totalCount.HasValue && totalCount.Value > 0 && (!AutoHidePaging || (AutoHidePaging && totalCount.Value > pageSize)))
+    {
+        <div class="d-flex justify-content-between align-middle flex-wrap">
+            <Pagination ActivePageNumber="@gridCurrentState.PageIndex"
+                        TotalPages="@totalPages"
+                        PageChanged="OnPageChangedAsync"
+                        FirstLinkIcon="IconName.ChevronDoubleLeft"
+                        PreviousLinkIcon="IconName.ChevronLeft"
+                        NextLinkIcon="IconName.ChevronRight"
+                        LastLinkIcon="IconName.ChevronDoubleRight"
+                        Alignment="Alignment.Start"
+                        Class="mb-0" />
+
+            @if (PageSizeSelectorVisible && PageSizeSelectorItems is not null && PageSizeSelectorItems.Any())
+            {
+                <div>
+                    <div class="d-flex justify-content-center align-middle">
+                        <div>
+                            <InputSelect class="form-select" role="button" TValue="int" Value="@pageSize" ValueExpression="() => pageSize" ValueChanged="async (value) => await OnPageSizeChangedAsync(value)">
+                                @foreach (var i in PageSizeSelectorItems)
+                                {
+                                    <option value="@i">@i</option>
+                                }
+                            </InputSelect>
+                        </div>
+                        <div class="bb-grid-pagination-text">@ItemsPerPageText</div>
+                    </div>
+                </div>
+            }
+
+            <div class="bb-grid-pagination-text">
+                @paginationItemsText
+            </div>
+        </div>
+    }
+
     var columnCount = columns.Where(c => c.IsVisible).Count();
     if (AllowSelection) columnCount += 1;
     if (AllowDetailView) columnCount += 1;
@@ -222,7 +258,7 @@
         </table>
     </div>
 
-    @if (AllowPaging && totalCount.HasValue && totalCount.Value > 0 && (!AutoHidePaging || (AutoHidePaging && totalCount.Value > pageSize)))
+    @if (AllowPaging && totalCount.HasValue && totalCount.Value > 0 && !PlacePaginationBeforeGrid && (!AutoHidePaging || (AutoHidePaging && totalCount.Value > pageSize)))
     {
         <div class="d-flex justify-content-between align-middle flex-wrap mt-2">
             <Pagination ActivePageNumber="@gridCurrentState.PageIndex"

--- a/blazorbootstrap/Components/Grid/Grid.razor.cs
+++ b/blazorbootstrap/Components/Grid/Grid.razor.cs
@@ -767,6 +767,18 @@ public partial class Grid<TItem> : BlazorBootstrapComponentBase
     public bool AutoHidePaging { get; set; }
 
     /// <summary>
+    /// Moves pagination from below the grid to above the grid.
+    /// <para>
+    /// Default value is <see langword="false"/>.
+    /// </para>
+    /// </summary>
+    [AddedVersion("")]
+    [DefaultValue(false)]
+    [Description("Moves pagination from below the grid to above the grid.")]
+    [Parameter]
+    public bool PlacePaginationBeforeGrid { get; set; }
+
+    /// <summary>
     /// Gets or sets the content to be rendered within the component.
     /// <para>
     /// Default value is <see langword="null"/>.


### PR DESCRIPTION
I've added an option to Grid that allows the pagination to come before the grid.

For very large grids, I wanted the user to be able to see that there were multiple pages without having to scroll down to the bottom.

I didn't know what to put for the version number of the parameter, so please advise or edit manually.

Note that the two blocks of code for the pagination are not identical due to styling differences.

Thanks